### PR TITLE
fix channel_layout references

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -282,21 +282,21 @@ audiomap="[0:a:0]channelsplit=channel_layout=4.0[a1][a2][a3][a4];[a1][a2]amerge,
         map2v="[stereo2]"
         ;;
         "1 Stereo Track")
-audiomap="[0:a:0]channelsplit=channel_layout=2[a1][a2];[a1][a2]amerge,aformat=channel_layouts=stereo[stereo1]"
+audiomap="[0:a:0]channelsplit=channel_layout=stereo[a1][a2];[a1][a2]amerge,aformat=channel_layouts=stereo[stereo1]"
         map1k="-map"
         map1v="[stereo1]"
         map2k=""
         map2v=""
         ;;
         "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono")
-audiomap="[0:a:0]channelsplit=channel_layout=2[a1][a2];[a1]aformat=channel_layouts=mono[mono1];[a2]aformat=channel_layouts=mono[mono2]"
+audiomap="[0:a:0]channelsplit=channel_layout=stereo[a1][a2];[a1]aformat=channel_layouts=mono[mono1];[a2]aformat=channel_layouts=mono[mono2]"
         map1k="-map"
         map1v="[mono1]"
         map2k="-map"
         map2v="[mono2]"
         ;;
         "Channel 2 -> 1st Track Mono, Channel 1 -> 2nd Track Mono")
-audiomap="[0:a:0]channelsplit=channel_layout=2[a1][a2];[a1]aformat=channel_layouts=mono[mono1];[a2]aformat=channel_layouts=mono[mono2]"
+audiomap="[0:a:0]channelsplit=channel_layout=stereo[a1][a2];[a1]aformat=channel_layouts=mono[mono1];[a2]aformat=channel_layouts=mono[mono2]"
         map1k="-map"
         map1v="[mono2]"
         map2k="-map"


### PR DESCRIPTION
`2` is not a valid channel layout name, changed to `stereo`

tested by @MIAPtech