### PR TITLE
add /tmp/bmdcapture.log to all bmdcapture calls

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1003,7 +1003,7 @@ fi
 if [[ "${runtype}" = "audiopassthrough" ]] ; then
     echo "ESC quit" > ~/.config/mpv/input.conf
     video_bitdepth=10
-    bmdcapture -m ${standard} -V "${video_input}" -A "${audio_input}" -c 8 -s 32 -p "${video_bitdepth}" -F nut -f pipe:1 | \
+    bmdcapture -m ${standard} -V "${video_input}" -A "${audio_input}" -c 8 -s 32 -p "${video_bitdepth}" -F nut -f pipe:1 2> /tmp/bmdcapture.log | \
         mpv - --title="mode:${runtype} - video:'${video_input_choice}' audio:'${audio_input_choice}'" -lavfi-complex "${playbackfilter}"	
     exit 0
 fi
@@ -1021,7 +1021,7 @@ fi
 
 if [[ "${runtype}" = "passthrough" ]] ; then
     video_bitdepth=10
-    bmdcapture -m ${standard} -V "${video_input}" -A "${audio_input}" -c 8 -s 32 -p "${video_bitdepth}" -F nut -f pipe:1 | \
+    bmdcapture -m ${standard} -V "${video_input}" -A "${audio_input}" -c 8 -s 32 -p "${video_bitdepth}" -F nut -f pipe:1 2> /tmp/bmdcapture.log | \
         ffplay -v info -hide_banner -stats -i - \
         -window_title "mode:${runtype} - video:'${video_input_choice}' audio:'${audio_input_choice}'" \
         -vf "${playbackfilter}"


### PR DESCRIPTION
since it is referenced in the video filterchain it needs to exist in
all potential calls