### PR TITLE
test if FFmpeg is correctly installed

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -3,11 +3,9 @@
 # vrecord
 # Open-source software for capturing a video signal and turning it into a digital file.
 
-if ffmpeg -version 2>&1 | grep "Library not loaded" >/dev/null; then
-    echo "Please wait while reinstalling 'FFmpeg'..."
-    brew reinstall ffmpeg \
-        && echo "OK: 'FFmpeg' reinstalled." \
-        || { echo "Error: 'FFmpeg' not installed correctly. Exiting." ; exit 1 ; }
+if ffmpeg -version 2>&1 | grep "Library not loaded" >/dev/null ; then
+    echo "Please reinstal 'FFmpeg'. Exiting."
+    exit 1
 fi
 
 config_file="$HOME/.$(basename "${0}").conf"

--- a/vrecord
+++ b/vrecord
@@ -3,6 +3,13 @@
 # vrecord
 # Open-source software for capturing a video signal and turning it into a digital file.
 
+if ffmpeg -version 2>&1 | grep "Library not loaded" >/dev/null; then
+    echo "Please wait while reinstalling 'FFmpeg'..."
+    brew reinstall ffmpeg \
+        && echo "OK: 'FFmpeg' reinstalled." \
+        || { echo "Error: 'FFmpeg' not installed correctly. Exiting." ; exit 1 ; }
+fi
+
 config_file="$HOME/.$(basename "${0}").conf"
 if [[ $(dirname $(which "${0}")) = "/usr/local/bin" ]] ; then
     version=$(TMP=$(brew info vrecord | grep -Eo "/vrecord/.* \(") ; echo ${TMP:9:(${#TMP}-11)})

--- a/vrecord
+++ b/vrecord
@@ -4,7 +4,7 @@
 # Open-source software for capturing a video signal and turning it into a digital file.
 
 if ffmpeg -version 2>&1 | grep "Library not loaded" >/dev/null ; then
-    echo "Please reinstal 'FFmpeg'. Exiting."
+    echo "Please reinstall 'FFmpeg'. Exiting."
     exit 1
 fi
 


### PR DESCRIPTION
Prevents e.g. the error:
```
dyld: Library not loaded: /usr/local/opt/x265/lib/libx265.116.dylib
  Referenced from: /usr/local/bin/ffmpeg
  Reason: image not found
Abort trap: 6
```
This may occur e.g. when `x265` has been updated, after installing `ffmpeg --with-x265`.