### PR TITLE
"full range visual" fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ All of options in the vrecord GUI (which appears when running `vrecord -e`) or o
 
 **Broadcast Range Visual mode** — Broadcast Range Visual mode displays the video feed, the video feed with pixels out of broadcast range highlighted, the waveform monitor, and the vectorscope in the vrecord window.
 
-**Full Range Visual mode** - Full Range Visual mode displays the video feed, the video feed with pixels out of full range highlighted, the waveform monitor, and the vectorscope in the vrecord window.
+**Full Range Visual mode** - Full Range Visual mode displays the video feed, the video feed with pixels at full range extremes highlighted, the waveform monitor, and the vectorscope in the vrecord window.
 
 **Visual + Numerical mode** — Visual and Numerical mode displays your favorite video feeds and scopes as well as numerical values for the characteristics of the video signal in the left sidebar. 
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ This documentation is up to date as of vrecord version 2017-07-15.
 
 ## Summary
 
-Vrecord is open-source software for capturing a video signal and turning it into a digital file. Its purpose is to make videotape digitization or transfer easier. Vrecord can capture analog and digital signals through a variety of inputs and can create digital video files in a variety of formats and codecs. Vrecord has been designed with needs of audiovisual archivists in mind.
+Vrecord is open-source software for capturing a video signal and turning it into a digital file. Its purpose is to make videotape digitization or transfer easier. Vrecord can capture analog and digital signals through a variety of inputs and can create digital video files in a variety of formats and codecs. Vrecord has been designed with needs of audiovisual archivists in mind. 
 
 Vrecord uses [ffmpeg](http://ffmpeg.org), [ffplay](http://ffmpeg.org/ffplay.html), and [bmdcapture](https://github.com/lu-zero/bmdtools) to do its dirty work.
 
-Currently vrecord only supports Blackmagic Design [capture cards](Resources/hardware.md) with the Blackmagic driver installed.
+Currently vrecord only supports Blackmagic Design [capture cards](Resources/hardware.md) with the Blackmagic driver installed. 
 
 ## Installing vrecord
 
@@ -72,15 +72,15 @@ Thus far installing vrecord on Linux using Linuxbrew has not been successful.
 
 ### Setting up vrecord for the First Time
 
-In macOS, open System Preferences and click on the icon for Blackmagic Design. If you do not see this icon in System Preferences you may not have installed the Blackmagic driver.
+In macOS, open System Preferences and click on the icon for Blackmagic Design. If you do not see this icon in System Preferences you may not have installed the Blackmagic driver. 
 
-Open up the Blackmagic Design preferences and click on the "Settings" tab. Select your input and output from the dropdown menu depending on what cables you have connected to the capture device.
+Open up the Blackmagic Design preferences and click on the "Settings" tab. Select your input and output from the dropdown menu depending on what cables you have connected to the capture device. 
 
-Once your capture device is set up you can start vrecord by simply opening up a [Terminal window](https://en.wikipedia.org/wiki/Terminal_%28OS_X%29) and typing
+Once your capture device is set up you can start vrecord by simply opening up a [Terminal window](https://en.wikipedia.org/wiki/Terminal_%28OS_X%29) and typing 
 ```
-vrecord
+vrecord 
 ```
-The first time you use vrecord you will be asked to make some initial choices about how you want to capture. Any decisions you make will be saved in a configuration file. But don't worry, you will be able to alter these decisions later.
+The first time you use vrecord you will be asked to make some initial choices about how you want to capture. Any decisions you make will be saved in a configuration file. But don't worry, you will be able to alter these decisions later. 
 Vrecord will ask you for video and audio inputs. These should agree with your settings for the Blackmagic capture device. Vrecord's other settings can be tailored to your liking. See the section on [Options for Video Capture](https://github.com/amiaopensource/vrecord#options-for-video-capture) below which explains all of the settings in detail.
 
 ### Basic Usage
@@ -95,10 +95,10 @@ For those who want the simplest possible explanation on how to use vrecord:
 1. Type in a unique identifier for your video file when prompted.
 1. Press "enter" to start recording.
 1. Let 'er rip! Play your tape!
-1. Let vrecord do its thing. Don't type any keys while the vrecord window is open, do not click the mouse inside the vrecord window, and do not start another instance of vrecord on the same computer. In fact it's best not to open or use any other programs on the computer that is capturing. Overtaxing the computer could cause errors in the capture.
+1. Let vrecord do its thing. Don't type any keys while the vrecord window is open, do not click the mouse inside the vrecord window, and do not start another instance of vrecord on the same computer. In fact it's best not to open or use any other programs on the computer that is capturing. Overtaxing the computer could cause errors in the capture. 
 1. If you are finished recording and the vrecord window hasn't already closed, close the window.
 1. Check the Terminal window for any error messages. Hopefully you don't see any cows.  
-1. Check to make sure that your video and metadata files were successfully created.
+1. Check to make sure that your video and metadata files were successfully created. 
 1. Repeat steps 1–12 as needed.
 
 ### The vrecord Window
@@ -107,10 +107,10 @@ For those who want the simplest possible explanation on how to use vrecord:
 
 Shown above is the layout of the vrecord window in "Broadcast Range Visual" mode. Vrecord also includes a "Visual + Numerical" mode, which is discussed in the [Options for Video Capture](https://github.com/amiaopensource/vrecord#options-for-video-capture) section below.
 
-1. **Video feed** — Displays the entire 720 x 486 video signal coming through. The image will appear a bit more stretched than it does on a television monitor.
+1. **Video feed** — Displays the entire 720 x 486 video signal coming through. The image will appear a bit more stretched than it does on a television monitor. 
 1. **Video feed with broadcast-safe indicator** — Displays a feed of an underscanned version of the video signal. Pixels whose luminance or chrominance is outside of broadcast range are colored yellow. Due to space constraints in the vrecord window this feed will appear slightly squeezed.  
-1. **Waveform monitor** — Displays luminance values for each field of the signal separately. The bottom of the red bar in each window represents the upper limit for a broadcast safe white level. The top of the blue bar represents the broacast safe limit for a black level.
-1. **Vectorscope** — Displays chrominance values for the signal. The boxes represent the values for yellow, red, magenta, blue, cyan, and green. The boxes furthest from the center represent the broadcast limits for those colors.
+1. **Waveform monitor** — Displays luminance values for each field of the signal separately. The bottom of the red bar in each window represents the upper limit for a broadcast safe white level. The top of the blue bar represents the broacast safe limit for a black level. 
+1. **Vectorscope** — Displays chrominance values for the signal. The boxes represent the values for yellow, red, magenta, blue, cyan, and green. The boxes furthest from the center represent the broadcast limits for those colors. 
 
 ### Passthrough Mode
 
@@ -120,7 +120,7 @@ Run passthrough mode by typing:
 ```
 vrecord -p
 ```
-If you haven't already set up vrecord it will prompt you to make some selections related to your audio and video inputs. Otherwise the vrecord window will open up and start displaying any video signal coming through from the capture device.
+If you haven't already set up vrecord it will prompt you to make some selections related to your audio and video inputs. Otherwise the vrecord window will open up and start displaying any video signal coming through from the capture device. 
 
 ### Audio Passthrough Mode
 
@@ -133,7 +133,7 @@ vrecord -a
 
 ### Edit Mode
 
-Running vrecord in edit mode opens a GUI window that allows you to change your recording options and then start digitizing a tape.
+Running vrecord in edit mode opens a GUI window that allows you to change your recording options and then start digitizing a tape. 
 
 Run edit mode by typing:
 ```
@@ -141,7 +141,7 @@ vrecord -e
 ```
 After selecting all of your options and clicking "OK" the you will be prompted to enter a unique ID for the file. After the ID is entered, the incoming video signal will be recorded to a file with some associated metadata files. When you are done recording, close the vrecord window. If you've set a time limit for capture the vrecord window should automatically close when the time limit has been reached.
 
-By default vrecord will create a video file, a bmdcapture log, a framemd5 file (which creates an MD5 hash value [AKA a checksum] for every frame of video), an ffmpeg log, an ffplay log, and a capture options log (which records the options that you selected in the GUI like codec and video bit depth). Vrecord can also create a [QCTools](https://github.com/bavc/qctools) XML file, which records the characteristics of the video signal. This file can be imported into QCTools for further analysis.
+By default vrecord will create a video file, a bmdcapture log, a framemd5 file (which creates an MD5 hash value [AKA a checksum] for every frame of video), an ffmpeg log, an ffplay log, and a capture options log (which records the options that you selected in the GUI like codec and video bit depth). Vrecord can also create a [QCTools](https://github.com/bavc/qctools) XML file, which records the characteristics of the video signal. This file can be imported into QCTools for further analysis. 
 
 #### Options for Video Capture
 
@@ -155,24 +155,24 @@ All of options in the vrecord GUI (which appears when running `vrecord -e`) or o
 
 **Select file format** — Choose the file format that you want the video to be saved in. This is also often called the container.
 
-**Select codec for video** — Choose how you would like the video signal to be encoded digitally. You can choose from some uncompressed, lossless, and lossy codecs.
+**Select codec for video** — Choose how you would like the video signal to be encoded digitally. You can choose from some uncompressed, lossless, and lossy codecs. 
 
 **Select bit depth for video** — Choose the level of bit depth you would like for your video file. Vrecord currently supports 8 and 10-bit video capture.
 
-**Select audio channel mapping** — Choose how you want the audio to be captured. Currently vrecord captures audio at 24-bits and can only capture 4 tracks. The options are:
+**Select audio channel mapping** — Choose how you want the audio to be captured. Currently vrecord captures audio at 24-bits and can only capture 4 tracks. The options are: 
 * "2 Stereo Tracks" — For capturing videotape formats that have four tracks which are arranged as stereo pairs.
 * "1 Stereo Track (From Channels 1 & 2)" — For capturing videotape formats that have two channels of audio which were recorded as a stereo pair.
 * "1 Stereo Track (From Channels 3 & 4)" — Same as above, but creates stereo track from second pair of inputs.
-* "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono" — For capturing videotapes with audio recorded on Channel 1 only. Vrecord will capture the audio from Channel 1 and create a mono track.
-* "Channel 2 -> 1st Mono, Channel 1 -> 2nd Track Mono" — For capturing videotapes with with audio recorded on Channel 2 only. Vrecord will take the audio from Channel 2 and place it in a Channel 1 mono track.
+* "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono" — For capturing videotapes with audio recorded on Channel 1 only. Vrecord will capture the audio from Channel 1 and create a mono track. 
+* "Channel 2 -> 1st Mono, Channel 1 -> 2nd Track Mono" — For capturing videotapes with with audio recorded on Channel 2 only. Vrecord will take the audio from Channel 2 and place it in a Channel 1 mono track. 
 
 **Select standard** — Select the television standard of the tape you are digitizing. Currently vrecord only supports NTSC and PAL.
 
 **Broadcast Range Visual mode** — Broadcast Range Visual mode displays the video feed, the video feed with pixels out of broadcast range highlighted, the waveform monitor, and the vectorscope in the vrecord window.
 
-**Full Range Visual mode** - Full Range Visual mode displays the video feed, the video feed with pixels at full range extremes (0 or 255) highlighted, the waveform monitor, and the vectorscope in the vrecord window.
+**Full Range Visual mode** - Full Range Visual mode displays the video feed, the video feed with pixels out of full range highlighted, the waveform monitor, and the vectorscope in the vrecord window.
 
-**Visual + Numerical mode** — Visual and Numerical mode displays your favorite video feeds and scopes as well as numerical values for the characteristics of the video signal in the left sidebar.
+**Visual + Numerical mode** — Visual and Numerical mode displays your favorite video feeds and scopes as well as numerical values for the characteristics of the video signal in the left sidebar. 
 
 ![Alt text](Resources/vrecord_visual_numerical_2016-11-22.jpg "Vrecord in Visual + Numerical Mode")
 
@@ -195,7 +195,7 @@ The numerical values are as follows:
 
 **Create QCTools XML** — While capturing the video signal, vrecord will also create an XML file that contains a record of the characteristics of the video signal (such as luminance, color saturation, audio levels, etc.). It will then compress the XML file using [gzip](https://www.gnu.org/software/gzip/). Choosing to create a QCTools XML is highly recommended. This file can be quickly imported into QCTools for further analysis of the video. In addition, if you choose this option, vrecord can analyze the video signal for potential errors. Currently vrecord only tests the saturation levels of the video, but more tests are coming soon!   
 
-**Frame MD5s** — You can choose to create an MD5 hash value (AKA a checksum) for each frame of video captured. A separate .md5 file with all the hash values will be created along with the video file. Generally choosing to create frame-level MD5s will not slow down or hinder the capture of your video. To read more about the value of frame-level MD5s see this article: http://dericed.com/papers/reconsidering-the-checksum-for-audiovisual-preservation/
+**Frame MD5s** — You can choose to create an MD5 hash value (AKA a checksum) for each frame of video captured. A separate .md5 file with all the hash values will be created along with the video file. Generally choosing to create frame-level MD5s will not slow down or hinder the capture of your video. To read more about the value of frame-level MD5s see this article: http://dericed.com/papers/reconsidering-the-checksum-for-audiovisual-preservation/ 
 
 **Set Recording time** — Set the amount of time (in minutes) that you would like vrecord to capture for. This number should be an integer or decimal. For example, if you are digitizing a tape with a capacity of 30 minutes of video, you might want set vrecord to capture for 33 minutes. After 33 minutes vrecord will automatically stop recording and shut down.
 
@@ -203,15 +203,15 @@ The numerical values are as follows:
 
 **Invert Second Channel of Audio** — This option allows you to invert the phase of the second channel of audio on ingest.  This option is only for rare cases. Use only if you are positive that the audio channels are 180 degrees out of phase!
 
-Click "OK" when you are finished with your selections. Vrecord will save all of your selections to a configuration file. If any selections are "Undeclared" vrecord will prompt you in the terminal window to make a choice.
+Click "OK" when you are finished with your selections. Vrecord will save all of your selections to a configuration file. If any selections are "Undeclared" vrecord will prompt you in the terminal window to make a choice. 
 
-Vrecord will then prompt you for a unique ID. The ID that you type in will become a prefix for the filename of all the resulting files in that recording session. After entering your unique ID you will be asked to press enter to start recording. Press enter and start playing your tape. The vrecord window will appear. Do not type any keys or click the mouse inside the window while the vrecord is working.
+Vrecord will then prompt you for a unique ID. The ID that you type in will become a prefix for the filename of all the resulting files in that recording session. After entering your unique ID you will be asked to press enter to start recording. Press enter and start playing your tape. The vrecord window will appear. Do not type any keys or click the mouse inside the window while the vrecord is working. 
 
 After the transfer is finished, vrecord will automatically check to make sure that no frames were missed during the capture. Check the Terminal window for any error messages. If frames were missed you may get the following message: "WARNING: There were pts discontinuities for these frame ranges: ##-##. The file may have sync issues." The message will give the frame numbers that are missing. Check the file immediately at these points and throughout the video to make sure there are no sync issues. The tape may need to be redigitized.
 
 ### GUI Mode
 
-Running vrecord in GUI mode opens a window that allows you to access any of vrecord's other modes (Record, Passthrough, Audio Passthrough, and Edit) via a friendly GUI.
+Running vrecord in GUI mode opens a window that allows you to access any of vrecord's other modes (Record, Passthrough, Audio Passthrough, and Edit) via a friendly GUI. 
 
 Run GUI mode by typing:
 ```
@@ -228,9 +228,9 @@ If you are finished recording and the vrecord window hasn't already closed, clos
 ### A Few Quirks
 
 ##### Timing of Recording
-When you start recording there may be several seconds of delay before the vrecord window actually appears. But don't worry, once you've pressed enter, vrecord is already capturing the signal and encoding it into a file.
+When you start recording there may be several seconds of delay before the vrecord window actually appears. But don't worry, once you've pressed enter, vrecord is already capturing the signal and encoding it into a file. 
 
-If you are watching the videotape output on a separate monitor and the video feeds on vrecord appear to be slightly behind the monitor, don't panic; all of your video has still been captured.
+If you are watching the videotape output on a separate monitor and the video feeds on vrecord appear to be slightly behind the monitor, don't panic; all of your video has still been captured. 
 
 ##### FFmpeg Error Message
 
@@ -242,7 +242,7 @@ Error while decoding stream #0:0: Invalid data found when processing input
 [v210 @ 0x7fe62301c000] packet too small
 ```
 
-You can safely ignore this warning, it's just FFmpeg complaining that it didn't receive a full frame of video when vrecord stopped.
+You can safely ignore this warning, it's just FFmpeg complaining that it didn't receive a full frame of video when vrecord stopped. 
 
 ### Clearing the Configuration File
 
@@ -251,7 +251,7 @@ By default vrecord saves the choices you made the last time you used the program
 ```
 vrecord -x
 ```
-Vrecord will then prompt you to make selections for video capture and proceed to start recording a new tape. If you want to interrupt vrecord hold down control + c.
+Vrecord will then prompt you to make selections for video capture and proceed to start recording a new tape. If you want to interrupt vrecord hold down control + c. 
 
 ## Help and Issues
 
@@ -268,7 +268,7 @@ If you want to see a more detailed description about how to digitize analog vide
 
 A short information about the [needed hardware](Resources/hardware.md) is provided as well.
 
-We want vrecord to be a helpful tool for audiovisual archivists and others. If you experience any problems with vrecord you can open a new issue with our GitHub [issue tracker](https://github.com/amiaopensource/vrecord/issues). Try to see if you can replicate the issue yourself first and describe in detail what factors led to it. Please let us know if you were able to successfully replicate the issue.
+We want vrecord to be a helpful tool for audiovisual archivists and others. If you experience any problems with vrecord you can open a new issue with our GitHub [issue tracker](https://github.com/amiaopensource/vrecord/issues). Try to see if you can replicate the issue yourself first and describe in detail what factors led to it. Please let us know if you were able to successfully replicate the issue. 
 
 Feel free to contribute to our GitHub project by creating a fork and sending pull requests.
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ This documentation is up to date as of vrecord version 2017-07-15.
 
 ## Summary
 
-Vrecord is open-source software for capturing a video signal and turning it into a digital file. Its purpose is to make videotape digitization or transfer easier. Vrecord can capture analog and digital signals through a variety of inputs and can create digital video files in a variety of formats and codecs. Vrecord has been designed with needs of audiovisual archivists in mind. 
+Vrecord is open-source software for capturing a video signal and turning it into a digital file. Its purpose is to make videotape digitization or transfer easier. Vrecord can capture analog and digital signals through a variety of inputs and can create digital video files in a variety of formats and codecs. Vrecord has been designed with needs of audiovisual archivists in mind.
 
 Vrecord uses [ffmpeg](http://ffmpeg.org), [ffplay](http://ffmpeg.org/ffplay.html), and [bmdcapture](https://github.com/lu-zero/bmdtools) to do its dirty work.
 
-Currently vrecord only supports Blackmagic Design [capture cards](Resources/hardware.md) with the Blackmagic driver installed. 
+Currently vrecord only supports Blackmagic Design [capture cards](Resources/hardware.md) with the Blackmagic driver installed.
 
 ## Installing vrecord
 
@@ -72,15 +72,15 @@ Thus far installing vrecord on Linux using Linuxbrew has not been successful.
 
 ### Setting up vrecord for the First Time
 
-In macOS, open System Preferences and click on the icon for Blackmagic Design. If you do not see this icon in System Preferences you may not have installed the Blackmagic driver. 
+In macOS, open System Preferences and click on the icon for Blackmagic Design. If you do not see this icon in System Preferences you may not have installed the Blackmagic driver.
 
-Open up the Blackmagic Design preferences and click on the "Settings" tab. Select your input and output from the dropdown menu depending on what cables you have connected to the capture device. 
+Open up the Blackmagic Design preferences and click on the "Settings" tab. Select your input and output from the dropdown menu depending on what cables you have connected to the capture device.
 
-Once your capture device is set up you can start vrecord by simply opening up a [Terminal window](https://en.wikipedia.org/wiki/Terminal_%28OS_X%29) and typing 
+Once your capture device is set up you can start vrecord by simply opening up a [Terminal window](https://en.wikipedia.org/wiki/Terminal_%28OS_X%29) and typing
 ```
-vrecord 
+vrecord
 ```
-The first time you use vrecord you will be asked to make some initial choices about how you want to capture. Any decisions you make will be saved in a configuration file. But don't worry, you will be able to alter these decisions later. 
+The first time you use vrecord you will be asked to make some initial choices about how you want to capture. Any decisions you make will be saved in a configuration file. But don't worry, you will be able to alter these decisions later.
 Vrecord will ask you for video and audio inputs. These should agree with your settings for the Blackmagic capture device. Vrecord's other settings can be tailored to your liking. See the section on [Options for Video Capture](https://github.com/amiaopensource/vrecord#options-for-video-capture) below which explains all of the settings in detail.
 
 ### Basic Usage
@@ -95,10 +95,10 @@ For those who want the simplest possible explanation on how to use vrecord:
 1. Type in a unique identifier for your video file when prompted.
 1. Press "enter" to start recording.
 1. Let 'er rip! Play your tape!
-1. Let vrecord do its thing. Don't type any keys while the vrecord window is open, do not click the mouse inside the vrecord window, and do not start another instance of vrecord on the same computer. In fact it's best not to open or use any other programs on the computer that is capturing. Overtaxing the computer could cause errors in the capture. 
+1. Let vrecord do its thing. Don't type any keys while the vrecord window is open, do not click the mouse inside the vrecord window, and do not start another instance of vrecord on the same computer. In fact it's best not to open or use any other programs on the computer that is capturing. Overtaxing the computer could cause errors in the capture.
 1. If you are finished recording and the vrecord window hasn't already closed, close the window.
 1. Check the Terminal window for any error messages. Hopefully you don't see any cows.  
-1. Check to make sure that your video and metadata files were successfully created. 
+1. Check to make sure that your video and metadata files were successfully created.
 1. Repeat steps 1–12 as needed.
 
 ### The vrecord Window
@@ -107,10 +107,10 @@ For those who want the simplest possible explanation on how to use vrecord:
 
 Shown above is the layout of the vrecord window in "Broadcast Range Visual" mode. Vrecord also includes a "Visual + Numerical" mode, which is discussed in the [Options for Video Capture](https://github.com/amiaopensource/vrecord#options-for-video-capture) section below.
 
-1. **Video feed** — Displays the entire 720 x 486 video signal coming through. The image will appear a bit more stretched than it does on a television monitor. 
+1. **Video feed** — Displays the entire 720 x 486 video signal coming through. The image will appear a bit more stretched than it does on a television monitor.
 1. **Video feed with broadcast-safe indicator** — Displays a feed of an underscanned version of the video signal. Pixels whose luminance or chrominance is outside of broadcast range are colored yellow. Due to space constraints in the vrecord window this feed will appear slightly squeezed.  
-1. **Waveform monitor** — Displays luminance values for each field of the signal separately. The bottom of the red bar in each window represents the upper limit for a broadcast safe white level. The top of the blue bar represents the broacast safe limit for a black level. 
-1. **Vectorscope** — Displays chrominance values for the signal. The boxes represent the values for yellow, red, magenta, blue, cyan, and green. The boxes furthest from the center represent the broadcast limits for those colors. 
+1. **Waveform monitor** — Displays luminance values for each field of the signal separately. The bottom of the red bar in each window represents the upper limit for a broadcast safe white level. The top of the blue bar represents the broacast safe limit for a black level.
+1. **Vectorscope** — Displays chrominance values for the signal. The boxes represent the values for yellow, red, magenta, blue, cyan, and green. The boxes furthest from the center represent the broadcast limits for those colors.
 
 ### Passthrough Mode
 
@@ -120,7 +120,7 @@ Run passthrough mode by typing:
 ```
 vrecord -p
 ```
-If you haven't already set up vrecord it will prompt you to make some selections related to your audio and video inputs. Otherwise the vrecord window will open up and start displaying any video signal coming through from the capture device. 
+If you haven't already set up vrecord it will prompt you to make some selections related to your audio and video inputs. Otherwise the vrecord window will open up and start displaying any video signal coming through from the capture device.
 
 ### Audio Passthrough Mode
 
@@ -133,7 +133,7 @@ vrecord -a
 
 ### Edit Mode
 
-Running vrecord in edit mode opens a GUI window that allows you to change your recording options and then start digitizing a tape. 
+Running vrecord in edit mode opens a GUI window that allows you to change your recording options and then start digitizing a tape.
 
 Run edit mode by typing:
 ```
@@ -141,7 +141,7 @@ vrecord -e
 ```
 After selecting all of your options and clicking "OK" the you will be prompted to enter a unique ID for the file. After the ID is entered, the incoming video signal will be recorded to a file with some associated metadata files. When you are done recording, close the vrecord window. If you've set a time limit for capture the vrecord window should automatically close when the time limit has been reached.
 
-By default vrecord will create a video file, a bmdcapture log, a framemd5 file (which creates an MD5 hash value [AKA a checksum] for every frame of video), an ffmpeg log, an ffplay log, and a capture options log (which records the options that you selected in the GUI like codec and video bit depth). Vrecord can also create a [QCTools](https://github.com/bavc/qctools) XML file, which records the characteristics of the video signal. This file can be imported into QCTools for further analysis. 
+By default vrecord will create a video file, a bmdcapture log, a framemd5 file (which creates an MD5 hash value [AKA a checksum] for every frame of video), an ffmpeg log, an ffplay log, and a capture options log (which records the options that you selected in the GUI like codec and video bit depth). Vrecord can also create a [QCTools](https://github.com/bavc/qctools) XML file, which records the characteristics of the video signal. This file can be imported into QCTools for further analysis.
 
 #### Options for Video Capture
 
@@ -155,24 +155,24 @@ All of options in the vrecord GUI (which appears when running `vrecord -e`) or o
 
 **Select file format** — Choose the file format that you want the video to be saved in. This is also often called the container.
 
-**Select codec for video** — Choose how you would like the video signal to be encoded digitally. You can choose from some uncompressed, lossless, and lossy codecs. 
+**Select codec for video** — Choose how you would like the video signal to be encoded digitally. You can choose from some uncompressed, lossless, and lossy codecs.
 
 **Select bit depth for video** — Choose the level of bit depth you would like for your video file. Vrecord currently supports 8 and 10-bit video capture.
 
-**Select audio channel mapping** — Choose how you want the audio to be captured. Currently vrecord captures audio at 24-bits and can only capture 4 tracks. The options are: 
+**Select audio channel mapping** — Choose how you want the audio to be captured. Currently vrecord captures audio at 24-bits and can only capture 4 tracks. The options are:
 * "2 Stereo Tracks" — For capturing videotape formats that have four tracks which are arranged as stereo pairs.
 * "1 Stereo Track (From Channels 1 & 2)" — For capturing videotape formats that have two channels of audio which were recorded as a stereo pair.
 * "1 Stereo Track (From Channels 3 & 4)" — Same as above, but creates stereo track from second pair of inputs.
-* "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono" — For capturing videotapes with audio recorded on Channel 1 only. Vrecord will capture the audio from Channel 1 and create a mono track. 
-* "Channel 2 -> 1st Mono, Channel 1 -> 2nd Track Mono" — For capturing videotapes with with audio recorded on Channel 2 only. Vrecord will take the audio from Channel 2 and place it in a Channel 1 mono track. 
+* "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono" — For capturing videotapes with audio recorded on Channel 1 only. Vrecord will capture the audio from Channel 1 and create a mono track.
+* "Channel 2 -> 1st Mono, Channel 1 -> 2nd Track Mono" — For capturing videotapes with with audio recorded on Channel 2 only. Vrecord will take the audio from Channel 2 and place it in a Channel 1 mono track.
 
 **Select standard** — Select the television standard of the tape you are digitizing. Currently vrecord only supports NTSC and PAL.
 
 **Broadcast Range Visual mode** — Broadcast Range Visual mode displays the video feed, the video feed with pixels out of broadcast range highlighted, the waveform monitor, and the vectorscope in the vrecord window.
 
-**Full Range Visual mode** - Full Range Visual mode displays the video feed, the video feed with pixels out of full range highlighted, the waveform monitor, and the vectorscope in the vrecord window.
+**Full Range Visual mode** - Full Range Visual mode displays the video feed, the video feed with pixels at full range extremes (0 or 255) highlighted, the waveform monitor, and the vectorscope in the vrecord window.
 
-**Visual + Numerical mode** — Visual and Numerical mode displays your favorite video feeds and scopes as well as numerical values for the characteristics of the video signal in the left sidebar. 
+**Visual + Numerical mode** — Visual and Numerical mode displays your favorite video feeds and scopes as well as numerical values for the characteristics of the video signal in the left sidebar.
 
 ![Alt text](Resources/vrecord_visual_numerical_2016-11-22.jpg "Vrecord in Visual + Numerical Mode")
 
@@ -195,7 +195,7 @@ The numerical values are as follows:
 
 **Create QCTools XML** — While capturing the video signal, vrecord will also create an XML file that contains a record of the characteristics of the video signal (such as luminance, color saturation, audio levels, etc.). It will then compress the XML file using [gzip](https://www.gnu.org/software/gzip/). Choosing to create a QCTools XML is highly recommended. This file can be quickly imported into QCTools for further analysis of the video. In addition, if you choose this option, vrecord can analyze the video signal for potential errors. Currently vrecord only tests the saturation levels of the video, but more tests are coming soon!   
 
-**Frame MD5s** — You can choose to create an MD5 hash value (AKA a checksum) for each frame of video captured. A separate .md5 file with all the hash values will be created along with the video file. Generally choosing to create frame-level MD5s will not slow down or hinder the capture of your video. To read more about the value of frame-level MD5s see this article: http://dericed.com/papers/reconsidering-the-checksum-for-audiovisual-preservation/ 
+**Frame MD5s** — You can choose to create an MD5 hash value (AKA a checksum) for each frame of video captured. A separate .md5 file with all the hash values will be created along with the video file. Generally choosing to create frame-level MD5s will not slow down or hinder the capture of your video. To read more about the value of frame-level MD5s see this article: http://dericed.com/papers/reconsidering-the-checksum-for-audiovisual-preservation/
 
 **Set Recording time** — Set the amount of time (in minutes) that you would like vrecord to capture for. This number should be an integer or decimal. For example, if you are digitizing a tape with a capacity of 30 minutes of video, you might want set vrecord to capture for 33 minutes. After 33 minutes vrecord will automatically stop recording and shut down.
 
@@ -203,15 +203,15 @@ The numerical values are as follows:
 
 **Invert Second Channel of Audio** — This option allows you to invert the phase of the second channel of audio on ingest.  This option is only for rare cases. Use only if you are positive that the audio channels are 180 degrees out of phase!
 
-Click "OK" when you are finished with your selections. Vrecord will save all of your selections to a configuration file. If any selections are "Undeclared" vrecord will prompt you in the terminal window to make a choice. 
+Click "OK" when you are finished with your selections. Vrecord will save all of your selections to a configuration file. If any selections are "Undeclared" vrecord will prompt you in the terminal window to make a choice.
 
-Vrecord will then prompt you for a unique ID. The ID that you type in will become a prefix for the filename of all the resulting files in that recording session. After entering your unique ID you will be asked to press enter to start recording. Press enter and start playing your tape. The vrecord window will appear. Do not type any keys or click the mouse inside the window while the vrecord is working. 
+Vrecord will then prompt you for a unique ID. The ID that you type in will become a prefix for the filename of all the resulting files in that recording session. After entering your unique ID you will be asked to press enter to start recording. Press enter and start playing your tape. The vrecord window will appear. Do not type any keys or click the mouse inside the window while the vrecord is working.
 
 After the transfer is finished, vrecord will automatically check to make sure that no frames were missed during the capture. Check the Terminal window for any error messages. If frames were missed you may get the following message: "WARNING: There were pts discontinuities for these frame ranges: ##-##. The file may have sync issues." The message will give the frame numbers that are missing. Check the file immediately at these points and throughout the video to make sure there are no sync issues. The tape may need to be redigitized.
 
 ### GUI Mode
 
-Running vrecord in GUI mode opens a window that allows you to access any of vrecord's other modes (Record, Passthrough, Audio Passthrough, and Edit) via a friendly GUI. 
+Running vrecord in GUI mode opens a window that allows you to access any of vrecord's other modes (Record, Passthrough, Audio Passthrough, and Edit) via a friendly GUI.
 
 Run GUI mode by typing:
 ```
@@ -228,9 +228,9 @@ If you are finished recording and the vrecord window hasn't already closed, clos
 ### A Few Quirks
 
 ##### Timing of Recording
-When you start recording there may be several seconds of delay before the vrecord window actually appears. But don't worry, once you've pressed enter, vrecord is already capturing the signal and encoding it into a file. 
+When you start recording there may be several seconds of delay before the vrecord window actually appears. But don't worry, once you've pressed enter, vrecord is already capturing the signal and encoding it into a file.
 
-If you are watching the videotape output on a separate monitor and the video feeds on vrecord appear to be slightly behind the monitor, don't panic; all of your video has still been captured. 
+If you are watching the videotape output on a separate monitor and the video feeds on vrecord appear to be slightly behind the monitor, don't panic; all of your video has still been captured.
 
 ##### FFmpeg Error Message
 
@@ -242,7 +242,7 @@ Error while decoding stream #0:0: Invalid data found when processing input
 [v210 @ 0x7fe62301c000] packet too small
 ```
 
-You can safely ignore this warning, it's just FFmpeg complaining that it didn't receive a full frame of video when vrecord stopped. 
+You can safely ignore this warning, it's just FFmpeg complaining that it didn't receive a full frame of video when vrecord stopped.
 
 ### Clearing the Configuration File
 
@@ -251,7 +251,7 @@ By default vrecord saves the choices you made the last time you used the program
 ```
 vrecord -x
 ```
-Vrecord will then prompt you to make selections for video capture and proceed to start recording a new tape. If you want to interrupt vrecord hold down control + c. 
+Vrecord will then prompt you to make selections for video capture and proceed to start recording a new tape. If you want to interrupt vrecord hold down control + c.
 
 ## Help and Issues
 
@@ -268,7 +268,7 @@ If you want to see a more detailed description about how to digitize analog vide
 
 A short information about the [needed hardware](Resources/hardware.md) is provided as well.
 
-We want vrecord to be a helpful tool for audiovisual archivists and others. If you experience any problems with vrecord you can open a new issue with our GitHub [issue tracker](https://github.com/amiaopensource/vrecord/issues). Try to see if you can replicate the issue yourself first and describe in detail what factors led to it. Please let us know if you were able to successfully replicate the issue. 
+We want vrecord to be a helpful tool for audiovisual archivists and others. If you experience any problems with vrecord you can open a new issue with our GitHub [issue tracker](https://github.com/amiaopensource/vrecord/issues). Try to see if you can replicate the issue yourself first and describe in detail what factors led to it. Please let us know if you were able to successfully replicate the issue.
 
 Feel free to contribute to our GitHub project by creating a fork and sending pull requests.
 

--- a/vrecord
+++ b/vrecord
@@ -194,36 +194,36 @@ set_up_drawtext(){
     echo -e "%{pts:hms}
 
   Y
- Low  %{metadata:lavfi.signalstats.YLOW}	
- Avg  %{metadata:lavfi.signalstats.YAVG}	
- High %{metadata:lavfi.signalstats.YHIGH}	
+ Low  %{metadata:lavfi.signalstats.YLOW}
+ Avg  %{metadata:lavfi.signalstats.YAVG}
+ High %{metadata:lavfi.signalstats.YHIGH}
  Diff %{metadata:lavfi.signalstats.YDIF}
 
   U
- Low  %{metadata:lavfi.signalstats.ULOW}	
- Avg  %{metadata:lavfi.signalstats.UAVG}	
- High %{metadata:lavfi.signalstats.UHIGH}	
+ Low  %{metadata:lavfi.signalstats.ULOW}
+ Avg  %{metadata:lavfi.signalstats.UAVG}
+ High %{metadata:lavfi.signalstats.UHIGH}
  Diff %{metadata:lavfi.signalstats.UDIF}
 
   V
- Low  %{metadata:lavfi.signalstats.VLOW}	
- Avg  %{metadata:lavfi.signalstats.VAVG}	
- High %{metadata:lavfi.signalstats.VHIGH}	
+ Low  %{metadata:lavfi.signalstats.VLOW}
+ Avg  %{metadata:lavfi.signalstats.VAVG}
+ High %{metadata:lavfi.signalstats.VHIGH}
  Diff %{metadata:lavfi.signalstats.VDIF}
 
   SAT
- Low  %{metadata:lavfi.signalstats.SATLOW}	
- Avg  %{metadata:lavfi.signalstats.SATAVG}	
- High %{metadata:lavfi.signalstats.SATHIGH}	
+ Low  %{metadata:lavfi.signalstats.SATLOW}
+ Avg  %{metadata:lavfi.signalstats.SATAVG}
+ High %{metadata:lavfi.signalstats.SATHIGH}
  " > /tmp/drawtext.txt
 
     echo -e "
- 
- 
- 
- 
- 
- 
+
+
+
+
+
+
 
 
 
@@ -579,7 +579,7 @@ split=5[a][b][c][d][e];\
 [c1]${WAVEFORM_FILTER}[c2];\
 [a][b2][c2]vstack=inputs=3,format=yuv422p[abc1];\
 [d]${VECTORSCOPE_FILTER}[d1];\
-[e]format=yuv444p,lutyuv=y=if(eq(val\,maxval)\,minval\,if(eq(val\,minval)\,maxval\,val)):u=val:v=val,scale=512:ih[e1];\
+[e]format=yuv444p,lutyuv=y=if(eq(val\,254)\,1\,if(eq(val\,1)\,254\,val)):u=val:v=val,scale=512:ih[e1];\
 [e1][d1]vstack[de1];\
 [abc1][de1]hstack[out]"
           ;;
@@ -748,7 +748,7 @@ standard_choice.default = ${standard_choice}
 standard_choice.option = ${undeclaredoption}
 standard_choice.option = NTSC
 standard_choice.option = PAL
-# frame md5 
+# frame md5
 framemd5_choice.x = 660
 framemd5_choice.y = 230
 framemd5_choice.type = radiobutton
@@ -757,7 +757,7 @@ framemd5_choice.default = ${framemd5_choice}
 framemd5_choice.option = ${undeclaredoption}
 framemd5_choice.option = Yes
 framemd5_choice.option = No
-# qctools xml 
+# qctools xml
 qctoolsxml_choice.x = 660
 qctoolsxml_choice.y = 317
 qctoolsxml_choice.type = radiobutton
@@ -895,7 +895,7 @@ if [[ "${runtype}" = "edit" ]] ; then
     pashua_run
     rm $pashua_configfile
     if [[ "$cb" = 0 ]] ; then
-        # check validity of duration value        
+        # check validity of duration value
         duration_check
         # report back options
         echo "Variables set:"
@@ -1029,7 +1029,7 @@ if [[ "${runtype}" = "audiopassthrough" ]] ; then
     echo "ESC quit" > ~/.config/mpv/input.conf
     video_bitdepth=10
     bmdcapture -m ${standard} -V "${video_input}" -A "${audio_input}" -c 8 -s 32 -p "${video_bitdepth}" -F nut -f pipe:1 2> /tmp/bmdcapture.log | \
-        mpv - --title="mode:${runtype} - video:'${video_input_choice}' audio:'${audio_input_choice}'" -lavfi-complex "${playbackfilter}"	
+        mpv - --title="mode:${runtype} - video:'${video_input_choice}' audio:'${audio_input_choice}'" -lavfi-complex "${playbackfilter}"
     exit 0
 fi
 
@@ -1243,7 +1243,7 @@ if [[ "${qctoolsxml_choice}" = "Yes" ]] ; then
             "${dir}/${id}${suffix}.${extension}" \
             "${extraoutputs[@]}" \
             -c:v copy -c:a copy -syncpoints none -f_strict experimental -f nut -y PIPE2QCTOOLS | ffprobe -loglevel error -f lavfi \
-            "movie=PIPE2QCTOOLS:s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng, cropdetect=reset=1,split[a][b]; 
+            "movie=PIPE2QCTOOLS:s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng, cropdetect=reset=1,split[a][b];
             [a]field=top[a1];[b]field=bottom[b1],[a1][b1]psnr[out0];[in1]ebur128=metadata=1,astats=metadata=1:reset=1:length=0.4[out1]" -show_frames -show_versions -of xml=x=1:q=1 -noprivate | gzip > "${logdir}/${id}${suffix}.${extension}.qctools.xml.gz"
     _report -d "Vrecord is analyzing your video file. Please be patient."
     if [[ "${video_bitdepth}" = "10" ]] ; then
@@ -1297,7 +1297,7 @@ if [[ "${framemd5_choice}" = "No" ]] ; then
     frames_decoded=$(cat "${logdir}/${id}"_ffmpeg_*.log | grep -w "frames decoded" | awk '{print $10}' | grep -m 1 [0-9])
     if [[ ${frames_encoded} -lt $((${frames_decoded}-1)) ]] ; then
         frame_discrepency=$((${frames_decoded}-${frames_encoded}))
-        cowsay "$(_report -w "WARNING: FFmpeg reported missing frames. The file may have sync issues.")" 
+        cowsay "$(_report -w "WARNING: FFmpeg reported missing frames. The file may have sync issues.")"
         _writeingestlog "ffmpeg_missing_frames" "${frame_discrepency}"
     else
         _writeingestlog "ffmpeg_missing_frames" "None"

--- a/vrecord
+++ b/vrecord
@@ -579,7 +579,7 @@ split=5[a][b][c][d][e];\
 [c1]${WAVEFORM_FILTER}[c2];\
 [a][b2][c2]vstack=inputs=3,format=yuv422p[abc1];\
 [d]${VECTORSCOPE_FILTER}[d1];\
-[e]format=yuv444p,lutyuv=y=if(eq(val\,maxval)\,minval\,if(eq(val\,minval)\,maxval\,val)):u=val:v=val,scale=512:ih[e1];\
+[e]format=yuv444p,lutyuv=y=if(eq(val\,254)\,1\,if(eq(val\,1)\,254\,val)):u=val:v=val,scale=512:ih[e1];\
 [e1][d1]vstack[de1];\
 [abc1][de1]hstack[out]"
           ;;

--- a/vrecord
+++ b/vrecord
@@ -194,36 +194,36 @@ set_up_drawtext(){
     echo -e "%{pts:hms}
 
   Y
- Low  %{metadata:lavfi.signalstats.YLOW}
- Avg  %{metadata:lavfi.signalstats.YAVG}
- High %{metadata:lavfi.signalstats.YHIGH}
+ Low  %{metadata:lavfi.signalstats.YLOW}	
+ Avg  %{metadata:lavfi.signalstats.YAVG}	
+ High %{metadata:lavfi.signalstats.YHIGH}	
  Diff %{metadata:lavfi.signalstats.YDIF}
 
   U
- Low  %{metadata:lavfi.signalstats.ULOW}
- Avg  %{metadata:lavfi.signalstats.UAVG}
- High %{metadata:lavfi.signalstats.UHIGH}
+ Low  %{metadata:lavfi.signalstats.ULOW}	
+ Avg  %{metadata:lavfi.signalstats.UAVG}	
+ High %{metadata:lavfi.signalstats.UHIGH}	
  Diff %{metadata:lavfi.signalstats.UDIF}
 
   V
- Low  %{metadata:lavfi.signalstats.VLOW}
- Avg  %{metadata:lavfi.signalstats.VAVG}
- High %{metadata:lavfi.signalstats.VHIGH}
+ Low  %{metadata:lavfi.signalstats.VLOW}	
+ Avg  %{metadata:lavfi.signalstats.VAVG}	
+ High %{metadata:lavfi.signalstats.VHIGH}	
  Diff %{metadata:lavfi.signalstats.VDIF}
 
   SAT
- Low  %{metadata:lavfi.signalstats.SATLOW}
- Avg  %{metadata:lavfi.signalstats.SATAVG}
- High %{metadata:lavfi.signalstats.SATHIGH}
+ Low  %{metadata:lavfi.signalstats.SATLOW}	
+ Avg  %{metadata:lavfi.signalstats.SATAVG}	
+ High %{metadata:lavfi.signalstats.SATHIGH}	
  " > /tmp/drawtext.txt
 
     echo -e "
-
-
-
-
-
-
+ 
+ 
+ 
+ 
+ 
+ 
 
 
 
@@ -579,7 +579,7 @@ split=5[a][b][c][d][e];\
 [c1]${WAVEFORM_FILTER}[c2];\
 [a][b2][c2]vstack=inputs=3,format=yuv422p[abc1];\
 [d]${VECTORSCOPE_FILTER}[d1];\
-[e]format=yuv444p,lutyuv=y=if(eq(val\,254)\,1\,if(eq(val\,1)\,254\,val)):u=val:v=val,scale=512:ih[e1];\
+[e]format=yuv444p,lutyuv=y=if(eq(val\,maxval)\,minval\,if(eq(val\,minval)\,maxval\,val)):u=val:v=val,scale=512:ih[e1];\
 [e1][d1]vstack[de1];\
 [abc1][de1]hstack[out]"
           ;;
@@ -748,7 +748,7 @@ standard_choice.default = ${standard_choice}
 standard_choice.option = ${undeclaredoption}
 standard_choice.option = NTSC
 standard_choice.option = PAL
-# frame md5
+# frame md5 
 framemd5_choice.x = 660
 framemd5_choice.y = 230
 framemd5_choice.type = radiobutton
@@ -757,7 +757,7 @@ framemd5_choice.default = ${framemd5_choice}
 framemd5_choice.option = ${undeclaredoption}
 framemd5_choice.option = Yes
 framemd5_choice.option = No
-# qctools xml
+# qctools xml 
 qctoolsxml_choice.x = 660
 qctoolsxml_choice.y = 317
 qctoolsxml_choice.type = radiobutton
@@ -895,7 +895,7 @@ if [[ "${runtype}" = "edit" ]] ; then
     pashua_run
     rm $pashua_configfile
     if [[ "$cb" = 0 ]] ; then
-        # check validity of duration value
+        # check validity of duration value        
         duration_check
         # report back options
         echo "Variables set:"
@@ -1029,7 +1029,7 @@ if [[ "${runtype}" = "audiopassthrough" ]] ; then
     echo "ESC quit" > ~/.config/mpv/input.conf
     video_bitdepth=10
     bmdcapture -m ${standard} -V "${video_input}" -A "${audio_input}" -c 8 -s 32 -p "${video_bitdepth}" -F nut -f pipe:1 2> /tmp/bmdcapture.log | \
-        mpv - --title="mode:${runtype} - video:'${video_input_choice}' audio:'${audio_input_choice}'" -lavfi-complex "${playbackfilter}"
+        mpv - --title="mode:${runtype} - video:'${video_input_choice}' audio:'${audio_input_choice}'" -lavfi-complex "${playbackfilter}"	
     exit 0
 fi
 
@@ -1243,7 +1243,7 @@ if [[ "${qctoolsxml_choice}" = "Yes" ]] ; then
             "${dir}/${id}${suffix}.${extension}" \
             "${extraoutputs[@]}" \
             -c:v copy -c:a copy -syncpoints none -f_strict experimental -f nut -y PIPE2QCTOOLS | ffprobe -loglevel error -f lavfi \
-            "movie=PIPE2QCTOOLS:s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng, cropdetect=reset=1,split[a][b];
+            "movie=PIPE2QCTOOLS:s=v+a[in0][in1],[in0]signalstats=stat=tout+vrep+brng, cropdetect=reset=1,split[a][b]; 
             [a]field=top[a1];[b]field=bottom[b1],[a1][b1]psnr[out0];[in1]ebur128=metadata=1,astats=metadata=1:reset=1:length=0.4[out1]" -show_frames -show_versions -of xml=x=1:q=1 -noprivate | gzip > "${logdir}/${id}${suffix}.${extension}.qctools.xml.gz"
     _report -d "Vrecord is analyzing your video file. Please be patient."
     if [[ "${video_bitdepth}" = "10" ]] ; then
@@ -1297,7 +1297,7 @@ if [[ "${framemd5_choice}" = "No" ]] ; then
     frames_decoded=$(cat "${logdir}/${id}"_ffmpeg_*.log | grep -w "frames decoded" | awk '{print $10}' | grep -m 1 [0-9])
     if [[ ${frames_encoded} -lt $((${frames_decoded}-1)) ]] ; then
         frame_discrepency=$((${frames_decoded}-${frames_encoded}))
-        cowsay "$(_report -w "WARNING: FFmpeg reported missing frames. The file may have sync issues.")"
+        cowsay "$(_report -w "WARNING: FFmpeg reported missing frames. The file may have sync issues.")" 
         _writeingestlog "ffmpeg_missing_frames" "${frame_discrepency}"
     else
         _writeingestlog "ffmpeg_missing_frames" "None"

--- a/vrecord
+++ b/vrecord
@@ -579,7 +579,7 @@ split=5[a][b][c][d][e];\
 [c1]${WAVEFORM_FILTER}[c2];\
 [a][b2][c2]vstack=inputs=3,format=yuv422p[abc1];\
 [d]${VECTORSCOPE_FILTER}[d1];\
-[e]format=yuv444p,lutyuv=y=if(eq(val\,254)\,1\,if(eq(val\,1)\,254\,val)):u=val:v=val,scale=512:ih[e1];\
+[e]format=yuv444p,lutyuv=y=if(gte(val\,254)\,1\,if(lte(val\,1)\,254\,val)):u=val:v=val,scale=512:ih[e1];\
 [e1][d1]vstack[de1];\
 [abc1][de1]hstack[out]"
           ;;


### PR DESCRIPTION
fix "Full Range Visual" to highlight pixels at full range extremes rather than at broadcast limits; re-worded description in README

addresses issue #173 

all other diffs are trailing whitespaces that I stripped out by accident, as I didn't realize Atom does that by default. can re-submit but I don't think it hurts anything?