### PR TITLE
adds interlaced support to prores stream

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -366,7 +366,7 @@ lookup_video_codec(){
             ;;
         "ProRes")
             codecname="Apple ProRes 422"
-            middleoptions+=(-c:v prores_ks)
+            middleoptions+=(-c:v prores_ks -flags +ilme+ildct)
             suffix="_prores"
             ;;
         "quit") _report -d "Bye then" ; exit 0 ;;


### PR DESCRIPTION
Hi,

From what I can see, not using `-flags +ilme+ildct` with `prores_ks` will result in a progressive prores stream. Are these flags OK? As `-vf setfield` is used earlier in the chain, the container metadata is set to interlaced.
So this is before the change:

```
Chroma subsampling                       : 4:2:2
Scan type                                : Interlaced
Original scan type                       : Progressive
Scan type, store method                  : Interleaved fields
Scan order                               : Top Field First 
```

and after

```
Chroma subsampling                       : 4:2:2
Scan type                                : Interlaced
Scan type, store method                  : Interleaved fields
Scan order                               : Top Field First
```