### PR TITLE
adds less specific qctools_xml conditional check

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1219,9 +1219,7 @@ if [[ "${qctoolsxml_choice}" = "Yes" ]] ; then
     fi
     AUD_OUTLIERS=$(gzcat "${logdir}/${id}${suffix}.${extension}.qctools.xml.gz" | xml sel -t -v "count(//tag[@key='lavfi.astats.Overall.Max_level'][@value>=0.999998])" -n)
     BRNG_OUTLIERS=$(gzcat "${logdir}/${id}${suffix}.${extension}.qctools.xml.gz" | xml sel -t -v "count(//tag[@key='lavfi.signalstats.BRNG'][@value>=0.03])" -n)
-fi
-
-if [[ "${qctoolsxml_choice}" = "No" ]] ; then
+else
     "${GRAB_DECKLINK[@]}" 2> >(tee "${logdir}/${id}${bmdcapturelogsuffix}" /tmp/bmdcapture.log >/dev/null) | \
         tee >(ffplay -i - -v info \
             -hide_banner -stats -autoexit \


### PR DESCRIPTION
The capture process will only launch if `$qctoolsxml_choice` is set to `Yes` or `No`.
If it is set to `undeclared` in the conf, then the terminal interview will appear.

By default, the value of `$qctoolsxml_choice` is `''`, so the interview does not launch. This pull request causes the capture process to run without a qctools option if `$qctoolsxml_choice` is set to anything but `Yes`.

Another way around this would be to make the terminal interview appear if `$qctoolsxml_choice` is set to `''`, but perhaps there is a reason why this is not the current behaviour?
