### PR TITLE
force text panels to use 8 bit

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -533,7 +533,7 @@ split=7[a][b][c][d][e][f][g];\
 [d]${VECTORSCOPE_FILTER}[d1];\
 [e]signalstats=out=brng,scale=512:ih[e1];\
 [e1][d1]vstack[de1];\
-[f]signalstats=stat=brng+vrep+tout,geq=lum=60:cb=128:cr=128,\
+[f]signalstats=stat=brng+vrep+tout,format=yuv422p,geq=lum=60:cb=128:cr=128,\
 scale=180:ih+512,setsar=1/1,\
 drawtext=fontcolor=white:fontsize=22:\
 fontfile=${defaultfont}:textfile=/tmp/drawtext.txt,\
@@ -542,7 +542,7 @@ fontfile=${defaultfont}:textfile=/tmp/drawtext2.txt,\
 drawtext=fontcolor=white:fontsize=52:\
 fontfile=${defaultfont}:textfile=/tmp/drawtext3.txt[f1];\
 [f1][abc1][de1]hstack=inputs=3[abcdef1];\
-[g]scale=iw+512+180:82,geq=lum=60:cb=128:cr=128,drawtext=fontcolor=white:fontsize=22:\
+[g]scale=iw+512+180:82,format=yuv422p,geq=lum=60:cb=128:cr=128,drawtext=fontcolor=white:fontsize=22:\
 fontfile=${defaultfont}:textfile=/tmp/bmdcapture.log:\
 reload=1:y=82-th[g1];\
 [abcdef1][g1]vstack[out]"


### PR DESCRIPTION
since https://git.ffmpeg.org/gitweb/ffmpeg.git/commit/ecc16d893dc0ee8b74bb179fedb5d077419eea23, geq supports >8 bit and thus the geq values for dark grey appear as green in 10 bit and gray in 8 bit. This forces the input to geq to be 8 bit. Thanks to @savcampbell for pointing this out.