### PR TITLE
`-h` in 80 chars width

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -40,7 +40,8 @@ $(basename "${0}") ${version}
 $(basename "${0}") will record a file via the Blackmagic SDK and ffmpeg. It is an
 interactive script and will create 8 or 10-bit video files.
 
-Dependencies: cowsay, amiaopensource/amiaos/ffmpegdecklink --with-sdl2 --with-freetype, mpv, qcli, and xmlstarlet
+Dependencies: cowsay, amiaopensource/amiaos/ffmpegdecklink --with-sdl2
+  --with-freetype, mpv, qcli, and xmlstarlet
 
 Usage: $(basename "${0}") [ -g | -e | -r | -p | -a | -x | -h ]
   -g  use the GUI


### PR DESCRIPTION
In order to avoid:
<img width="894" alt="bildschirmfoto 2017-12-15 um 19 21 55" src="https://user-images.githubusercontent.com/3246607/34054933-4c7792de-e1cd-11e7-80d4-5d10b2951529.png">
