### PR TITLE
reinstall message

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -29,7 +29,9 @@ FFMPEG_DECKLINK=($(brew --prefix ffmpegdecklink)/bin/ffmpeg-dl)
 FFPLAY_DECKLINK=($(brew --prefix ffmpegdecklink)/bin/ffplay-dl)
 
 if [[ "$("${FFMPEG_DECKLINK[@]}" -version 2>&1 | grep "Library not loaded" >/dev/null)" || ! -f "${FFMPEG_DECKLINK}" || ! -f "$FFPLAY_DECKLINK" ]] ; then
-    echo "Please reinstall 'ffmpeg-dl'. \`brew install amiaopensource/amiaos/ffmpegdecklink --with-sdl2 --with-freetype\` Exiting."
+    echo "Please reinstall 'ffmpeg-dl':"
+    echo "  brew reinstall amiaopensource/amiaos/ffmpegdecklink --with-sdl2 --with-freetype"
+    echo "Exiting."
     exit 1
 fi
 


### PR DESCRIPTION
- I guess, it’s clearer when the command is on its own line.
- `install` or `reinstall`? I unified to `reinstall`.