### PR TITLE
Embedding logs in Matroska files

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,11 @@ All of options in the vrecord GUI (which appears when running `vrecord -e`) or o
 
 **Frame MD5s** — You can choose to create an MD5 hash value (AKA a checksum) for each frame of video captured. A separate .md5 file with all the hash values will be created along with the video file. Generally choosing to create frame-level MD5s will not slow down or hinder the capture of your video. To read more about the value of frame-level MD5s see this article: http://dericed.com/papers/reconsidering-the-checksum-for-audiovisual-preservation/ 
 
+**Embedding logs** — If you choose Matroska, vrecord can embed the logs it generates into the Matroska container. Preservation metadata will then be available to the user both as sidecar logs (the vrecord default) and within the file itself. After logs have been attached, you can extract and read them as follows:
+* To show a list of attachments to a video file and their IDs, type: `mkvmerge -i [video filename]`
+* To extract attachments with IDs 1 through 4, type: `mkvextract [video filename] attachments 1 2 3 4`
+* The logs will then be extracted into the directory you're in, where they can be opened with a text editor.
+
 **Set recording time** — Set the amount of time (in minutes) that you would like vrecord to capture for, or leave it blank to capture indefinitely. For example, if you are digitizing a tape with a capacity of 30 minutes of video, you might want set vrecord to capture for 33 minutes. After 33 minutes vrecord will automatically stop recording and shut down. You may select a preset length from the dropdown menu, or type a different number. If you enter a number, it should be an integer or decimal in minutes (e.g. `15` will record for 15 minutes, and `15.75` will record for 15 minutes and 45 seconds).
 
 **Enter the name of the person digitizing this tape** — This field is optional. You can enter the name of the technician digitizing the tape. The name will be written to the capture options log produced at the end of the transfer.

--- a/vrecord
+++ b/vrecord
@@ -770,6 +770,15 @@ FRAMEMD5_CHOICE.default = ${FRAMEMD5_CHOICE}
 FRAMEMD5_CHOICE.option = ${UNDECLAREDOPTION}
 FRAMEMD5_CHOICE.option = Yes
 FRAMEMD5_CHOICE.option = No
+# embed logs choice
+EMBED_LOGS_CHOICE.x = 660
+EMBED_LOGS_CHOICE.y = 143
+EMBED_LOGS_CHOICE.type = radiobutton
+EMBED_LOGS_CHOICE.label = Embed digitization logs in video file? (Matroska only)
+EMBED_LOGS_CHOICE.default = ${EMBED_LOGS_CHOICE}
+EMBED_LOGS_CHOICE.option = ${UNDECLAREDOPTION}
+EMBED_LOGS_CHOICE.option = Yes
+EMBED_LOGS_CHOICE.option = No
 # playbackview choice
 PLAYBACKVIEW_CHOICE.x = 20
 PLAYBACKVIEW_CHOICE.y = 3
@@ -824,6 +833,7 @@ CHANNEL_MAPPING_OPTIONS=("2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, C
 STANDARD_OPTIONS=("NTSC" "PAL" "quit")
 QCTOOLSXML_OPTIONS=("Yes" "No" "quit")
 FRAMEMD5_OPTIONS=("Yes" "No" "quit")
+EMBED_LOGS_OPTIONS=("Yes" "No" "quit")
 PLAYBACKVIEW_OPTIONS=("Quality Control View (mpv)" "Broadcast Range Visual" "Full Range Visual" "Visual + Numerical" "Color Matrix" "Bit Planes" "quit")
 
 # comments to be printed to vrecord config file; must be commented (start with #)
@@ -838,6 +848,7 @@ AUDIO_MAPPING_CHOICE_COMMENT="#Set AUDIO_MAPPING_CHOICE to one of these valid op
 STANDARD_CHOICE_COMMENT="#Set STANDARD_CHOICE to one of these valid options or leave blank to request each run:  $(printf "\"%s\" " "${STANDARD_OPTIONS[@]}")"
 QCTOOLSXML_CHOICE_COMMENT="#Set QCTOOLSXML_CHOICE to one of these valid options or leave blank to request each run:  $(printf "\"%s\" " "${QCTOOLSXML_OPTIONS[@]}")"
 FRAMEMD5_CHOICE_COMMENT="#Set FRAMEMD5_CHOICE to one of these valid options or leave blank to request each run:  $(printf "\"%s\" " "${FRAMEMD5_OPTIONS[@]}")"
+EMBED_LOGS_CHOICE_COMMENT="#Set embed_choice to one of these valid options or leave blank to request each run:  $(printf "\"%s\" " "${EMBED_LOGS_OPTIONS[@]}")"
 PLAYBACKVIEW_CHOICE_COMMENT="#Set PLAYBACKVIEW_CHOICE to one of these valid options or leave blank to request each run:  $(printf "\"%s\" " "${PLAYBACKVIEW_OPTIONS[@]}")"
 DURATION_COMMENT="#Set the recording time as a number (integer or decimal) in minutes."
 TECHNICIAN_COMMENT="#Enter the name of the person digitizing this tape."
@@ -880,6 +891,7 @@ elif [[ "${RUNTYPE}" = "edit" ]] ; then
         echo "  STANDARD_CHOICE = ${STANDARD_CHOICE}"
         echo "  QCTOOLSXML_CHOICE = ${QCTOOLSXML_CHOICE}"
         echo "  FRAMEMD5_CHOICE = ${FRAMEMD5_CHOICE}"
+        echo "  EMBED_LOGS_CHOICE = ${EMBED_LOGS_CHOICE}"
         echo "  PLAYBACKVIEW_CHOICE = ${PLAYBACKVIEW_CHOICE}"
         echo "  DURATION = ${DURATION}"
         echo "  TECHNICIAN = ${TECHNICIAN}"
@@ -890,6 +902,9 @@ elif [[ "${RUNTYPE}" = "edit" ]] ; then
             echo -e " \033[101mWARNING: Incompatible video codecs and CONTAINERs have been selected\033[0m"
         elif [ "${VIDEO_CODEC_CHOICE}" = "ProRes" -a "${CONTAINER_CHOICE}" = "MXF" ] ; then
             echo -e " \033[101mWARNING: Incompatible video codecs and CONTAINERs have been selected\033[0m"
+        fi
+        if [ "${EMBED_LOGS_CHOICE}" = "Yes" -a "${CONTAINER_CHOICE}" != "Matroska" ] ; then
+            _report -w "WARNING: Logs cannot be embedded in non-Matroska files. This vrecord session will generate logs in ${LOGDIR}, but will not embed them in your video file."
         fi
         echo ""
         # write config file
@@ -922,6 +937,9 @@ QCTOOLSXML_CHOICE="${QCTOOLSXML_CHOICE}"
 
 ${FRAMEMD5_CHOICE_COMMENT}
 FRAMEMD5_CHOICE="${FRAMEMD5_CHOICE}"
+
+${EMBED_LOGS_CHOICE_COMMENT}
+EMBED_LOGS_CHOICE="${EMBED_LOGS_CHOICE}"
 
 ${PLAYBACKVIEW_CHOICE_COMMENT}
 PLAYBACKVIEW_CHOICE="${PLAYBACKVIEW_CHOICE}"
@@ -1166,6 +1184,17 @@ if [[ "${FRAMEMD5_CHOICE}" = "Yes" ]] ; then
     EXTRAOUTPUTS=(-an -f framemd5 "${FRAMEMD5NAME}")
 fi
 
+if [[ "${EMBED_LOGS_CHOICE}" != "${UNDECLAREDOPTION}" ]] ; then
+    echo ""
+elif [[ "${EMBED_LOGS_CHOICE}" = "${UNDECLAREDOPTION}" ]] && [[ "${CONTAINER_CHOICE}" = "Matroska" ]] ; then
+    _report -q "Embed logs in Matroska file?"
+    PS3="Select an option: "
+    select EMBED_LOGS_CHOICE in "${EMBED_LOGS_OPTIONS[@]}" ; do
+        _yes_or_no "${EMBED_LOGS_CHOICE}"
+        [[ "${?}" -eq 0 ]] && break
+    done
+fi
+
 _duration_check
 if [[ -n "${DURATION}" ]] ; then
     DUR_SECONDS=$(bc <<< "${DURATION} * 60")
@@ -1200,6 +1229,7 @@ _writeingestlog "AUDIO_MAPPING_CHOICE" "${AUDIO_MAPPING_CHOICE}"
 _writeingestlog "STANDARD_CHOICE" "${STANDARD_CHOICE}"
 _writeingestlog "QCTOOLSXML_CHOICE" "${QCTOOLSXML_CHOICE}"
 _writeingestlog "FRAMEMD5_CHOICE" "${FRAMEMD5_CHOICE}"
+_writeingestlog "EMBED_LOGS_CHOICE" "${EMBED_LOGS_CHOICE}"
 _writeingestlog "FILE_PATH" "${DIR}/${ID}.${EXTENSION}"
 if [[ -z "${TECHNICIAN}" ]] ; then
     _writeingestlog "TECHNICIAN" "N/A"
@@ -1341,7 +1371,7 @@ elif [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
 fi
 
 # embed logs in Matroska files
-if [[ "${container_choice}" = "Matroska" ]] ; then
+if [[ "${CONTAINER_CHOICE}" = "Matroska" && "${EMBED_LOGS_CHOICE}" = "Yes" ]]; then
     _report -d "Vrecord is attaching logs to your Matroska file:"
     mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${INGESTLOG}"
     mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${LOGDIR}/${ID}${CAPTURELOGSUFFIX}"

--- a/vrecord
+++ b/vrecord
@@ -371,53 +371,47 @@ _lookup_pixel_format(){
 _lookup_audio_mapping(){
     case "${1}" in
         "2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)")
-            AUDIOMAP="[0:a:0]pan=stereo| c0=c0 | c1="${PHASE_VALUE}"c1[stereo1];[0:a:0]pan=stereo| c0=c2 | c1=c3[stereo2]"
-            MAP1K="-map"
+            AUDIOMAP="[0:a:0]pan=stereo| c0=c0 | c1=${PHASE_VALUE}c1[stereo1];[0:a:0]pan=stereo| c0=c2 | c1=c3[stereo2]"
             MAP1V="[stereo1]"
-            MAP2K="-map"
             MAP2V="[stereo2]"
             ;;
         "1 Stereo Track (From Channels 1 & 2)")
-            AUDIOMAP="[0:a:0]pan=stereo| c0=c0 | c1="${PHASE_VALUE}"c1[stereo1]"
-            MAP1K="-map"
+            AUDIOMAP="[0:a:0]pan=stereo| c0=c0 | c1=${PHASE_VALUE}c1[stereo1]"
             MAP1V="[stereo1]"
-            MAP2K=""
             MAP2V=""
             ;;
         "1 Stereo Track (From Channels 3 & 4)")
-            AUDIOMAP="[0:a:0]pan=stereo| c0=c2 | c1="${PHASE_VALUE}"c3[stereo1]"
-            MAP1K="-map"
+            AUDIOMAP="[0:a:0]pan=stereo| c0=c2 | c1=${PHASE_VALUE}c3[stereo1]"
             MAP1V="[stereo1]"
-            MAP2K=""
             MAP2V=""
             ;;
         "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono")
-            AUDIOMAP="[0:a:0]pan=mono| c0=c0[mono1];[0:a:0]pan=mono| c0="${PHASE_VALUE}"c1[mono2]"
-            MAP1K="-map"
+            AUDIOMAP="[0:a:0]pan=mono| c0=c0[mono1];[0:a:0]pan=mono| c0=${PHASE_VALUE}c1[mono2]"
             MAP1V="[mono1]"
-            MAP2K="-map"
             MAP2V="[mono2]"
             ;;
         "Channel 2 -> 1st Track Mono, Channel 1 -> 2nd Track Mono")
-            AUDIOMAP="[0:a:0]pan=mono| c0="${PHASE_VALUE}"c1[mono1];[0:a:0]pan=mono| c0=c0[mono2]"
-            MAP1K="-map"
+            AUDIOMAP="[0:a:0]pan=mono| c0=${PHASE_VALUE}c1[mono1];[0:a:0]pan=mono| c0=c0[mono2]"
             MAP1V="[mono1]"
-            MAP2K="-map"
             MAP2V="[mono2]"
             ;;
         "Channel 1 -> Single Track Mono")
             AUDIOMAP="[0:a:0]pan=mono| c0=c0[mono1]"
-            MAP1K="-map"
             MAP1V="[mono1]"
             ;;
         "Channel 2 -> Single Track Mono")
             AUDIOMAP="[0:a:0]pan=mono| c0=c1[mono1]"
-            MAP1K="-map"
             MAP1V="[mono1]"
             ;;
         "quit") _report -d "Bye then" ; exit 0 ;;
         *) _report -w "Error: Not a valid option, select a valid number." ; return 1 ;;
     esac
+    if [[ -n "${MAP1V}" ]] ; then
+        AUDIO_CHANNEL_MAP+=(-map "${MAP1V}")
+    fi
+    if [[ -n "${MAP2V}" ]] ; then
+        AUDIO_CHANNEL_MAP+=(-map "${MAP2V}")
+    fi
 }
 
 _lookup_standard(){
@@ -1225,11 +1219,7 @@ if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then
         2> >(tee "${LOGDIR}/${ID}${CAPTURELOGSUFFIX}" /tmp/vrecord_input.log >/dev/null) \
         -v info -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_DECKLINK[@]}" \
         -metadata:s:v:0 encoder="${CODECNAME}" "${MIDDLEOPTIONS[@]}" -c:a pcm_s24le \
-        -filter_complex "\
-            [0:v:0]${RECORDINGFILTER};\
-            ${AUDIOMAP}" \
-        $(if [ -n "$MAP1K" ] ; then echo ${MAP1K} ; fi) $(if [ -n "$MAP1V" ] ; then echo ${MAP1V} ; fi) \
-        $(if [ -n "$MAP2K" ] ; then echo ${MAP2K} ; fi) $(if [ -n "$MAP2V" ] ; then echo ${MAP2V} ; fi) \
+        -filter_complex "[0:v:0]${RECORDINGFILTER}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" \
         -f "${FORMAT}" "${DIR}/${ID}${SUFFIX}.${EXTENSION}" \
         "${EXTRAOUTPUTS[@]}" -map 0 -c copy -f nut - | \
         if [[ "${QCTOOLSXML_CHOICE}" = "Yes" ]] ; then
@@ -1243,11 +1233,7 @@ else
         2> >(tee "${LOGDIR}/${ID}${CAPTURELOGSUFFIX}" /tmp/vrecord_input.log >/dev/null) \
         -v info -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_DECKLINK[@]}" \
         -metadata:s:v:0 encoder="${CODECNAME}" "${MIDDLEOPTIONS[@]}" -c:a pcm_s24le \
-        -filter_complex "\
-            [0:v:0]${RECORDINGFILTER};\
-            ${AUDIOMAP}" \
-        $(if [ -n "$MAP1K" ] ; then echo ${MAP1K} ; fi) $(if [ -n "$MAP1V" ] ; then echo ${MAP1V} ; fi) \
-        $(if [ -n "$MAP2K" ] ; then echo ${MAP2K} ; fi) $(if [ -n "$MAP2V" ] ; then echo ${MAP2V} ; fi) \
+        -filter_complex "[0:v:0]${RECORDINGFILTER}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" \
         -f "${FORMAT}" "${DIR}/${ID}${SUFFIX}.${EXTENSION}" \
         "${EXTRAOUTPUTS[@]}" -map 0 -c copy -f nut - | \
         if [[ "${QCTOOLSXML_CHOICE}" = "Yes" ]] ; then

--- a/vrecord
+++ b/vrecord
@@ -1211,7 +1211,8 @@ if [[ "${INVERT_PHASE}" = 1 ]] ; then
 fi
 
 _report -d "Close the playback window to stop recording."
-export FFREPORT="file=${LOGDIR}/${ID}_%p_%t${FFMPEGLOGSUFFIX}"
+FFREPORT_LOG="${LOGDIR}/${ID}_ffmpeg_$(date +%Y%m%d-%H%M%S)${FFMPEGLOGSUFFIX}"
+export FFREPORT="file=${FFREPORT_LOG}"
 
 # vrecord process!
 if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then
@@ -1344,6 +1345,7 @@ if [[ "${container_choice}" = "Matroska" ]] ; then
     _report -d "Vrecord is attaching logs to your Matroska file:"
     mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${INGESTLOG}"
     mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${LOGDIR}/${ID}${CAPTURELOGSUFFIX}"
+    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${FFREPORT_LOG}"
     if [[ "${QCTOOLSXML_CHOICE}" = "Yes" ]] ; then
         mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${QCXML}"
     fi

--- a/vrecord
+++ b/vrecord
@@ -1373,11 +1373,11 @@ fi
 # embed logs in Matroska files
 if [[ "${CONTAINER_CHOICE}" = "Matroska" && "${EMBED_LOGS_CHOICE}" = "Yes" ]]; then
     _report -d "Vrecord is attaching logs to your Matroska file:"
-    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${INGESTLOG}"
-    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${LOGDIR}/${ID}${CAPTURELOGSUFFIX}"
-    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${FFREPORT_LOG}"
+    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --attachment-description "Capture options selected by user during vrecord process" --add-attachment "${INGESTLOG}"
+    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --attachment-description "Description of vrecord input (as captured from decklink) and output (written to files)" --add-attachment "${LOGDIR}/${ID}${CAPTURELOGSUFFIX}"
+    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --attachment-description "Full FFmpeg output from vrecord capture process" --add-attachment "${FFREPORT_LOG}"
     if [[ "${QCTOOLSXML_CHOICE}" = "Yes" ]] ; then
-        mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${QCXML}"
+        mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --attachment-description "QCTools report from vrecord capture process (zipped XML)" --add-attachment "${QCXML}"
     fi
     _report -d "Vrecord is done attaching logs to your Matroska file!"
 fi

--- a/vrecord
+++ b/vrecord
@@ -1338,3 +1338,14 @@ elif [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
         mediaconch -p "${SCRIPTDIR}/vrecord_policy_ffv1.xml" "${DIR}/${ID}${SUFFIX}.${EXTENSION}"
     fi
 fi
+
+# embed logs in Matroska files
+if [[ "${container_choice}" = "Matroska" ]] ; then
+    _report -d "Vrecord is attaching logs to your Matroska file:"
+    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${INGESTLOG}"
+    mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${LOGDIR}/${ID}${CAPTURELOGSUFFIX}"
+    if [[ "${QCTOOLSXML_CHOICE}" = "Yes" ]] ; then
+        mkvpropedit "${DIR}/${ID}${SUFFIX}.${EXTENSION}" --add-attachment "${QCXML}"
+    fi
+    _report -d "Vrecord is done attaching logs to your Matroska file!"
+fi


### PR DESCRIPTION
Adding embedded logs alongside the sidecar files for those working with Matroska!

This step currently takes place after the MediaConch policy evaluations because MediaConch parses out the attachments themselves to evaluate them as video files (a reported bug).