### PR TITLE
better parsing to get decklink name

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -98,7 +98,7 @@ _report(){
 }
 
 _get_decklink_inputs(){
-    DECKLINK_INPUTS=$("${FFMPEG_DECKLINK[@]}" -f decklink -list_devices 1 -i dummy 2>&1 | grep "^\[decklink" | grep "'" | cut -d "'" -f 2)
+    DECKLINK_INPUTS=$("${FFMPEG_DECKLINK[@]}" -f decklink -list_devices 1 -i dummy 2>&1 | grep -o "^\[decklink[^\]*][^']*'.*" | cut -d "'" -f2- | sed "s/'$//g")
     if [[ -z "${DECKLINK_INPUTS}" ]] ; then
         _report -w "No decklink inputs were found. Running \`${FFMPEG_DECKLINK} -hide_banner -f decklink -list_devices 1 -i dummy\` results in:"
         "${FFMPEG_DECKLINK[@]}" -hide_banner -f decklink -list_devices 1 -i dummy


### PR DESCRIPTION
prior one would fail if the device name contained a single quote. Hopes to fix https://github.com/amiaopensource/vrecord/issues/270.
