### PR TITLE
rely more on ffmpeg's decklink device warnings

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -128,11 +128,7 @@ _get_decklink_inputs(){
         _report -w "No decklink inputs were found. Running \`${FFMPEG_DECKLINK} -hide_banner -f decklink -list_devices 1 -i dummy\` results in:"
         DECKLINK_RESULT=$("${FFMPEG_DECKLINK[@]}" -hide_banner -f decklink -list_devices 1 -i dummy)
         echo "${DECKLINK_RESULT}"
-        if [[ "$(echo "${DECKLINK_RESULT}" | grep -c "Could not create DeckLink iterator")" ]] ; then
-            _report -w "You may need a newer version of Blackmagic Desktop Video, see https://www.blackmagicdesign.com/support/."
-        else
-            _report -w "Please check connections and try again."
-        fi
+        _report -w "Please check connections and drivers and try again."
         exit 1
     else
         FIRST_DECKLINK_INPUT="$(echo "${DECKLINK_INPUTS}" | head -n 1 )"


### PR DESCRIPTION
now ffmpeg will log an error about drivers https://git.ffmpeg.org/gitweb/ffmpeg.git/blobdiff/30270561608a2a73c0dd9e73e346addff58f0f35..768c0774d82c8dc8eb9c14684b619b0d3b4e2f05:/libavdevice/decklink_common.cpp

resolves https://github.com/amiaopensource/vrecord/issues/305