### PR TITLE
set ffplay to only use the first two channels for playback

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1070,6 +1070,7 @@ FFPLAY_OPTIONS+=(-window_title "${WINDOW_NAME}")
 if [[ ! -z "${PLAYBACKFILTER}" ]] ; then
     FFPLAY_OPTIONS+=(-vf "${PLAYBACKFILTER}")
 fi
+FFPLAY_OPTIONS+=(-af "channelmap=0|1:stereo")
 
 # CLI passthrough and audiopassthrough modes
 if [[ "${RUNTYPE}" = "passthrough" ]] ; then


### PR DESCRIPTION
SDL_OpenAudio does not support 8 channel audio

resolves https://github.com/amiaopensource/vrecord/issues/200