### PR TITLE
use alternate mediainfo expressions for BT.470 B/G

### DIFF
--- a/vrecord_policy_ffv1.xml
+++ b/vrecord_policy_ffv1.xml
@@ -19,7 +19,10 @@
                 <policy type="and" name="Is it PAL?">
                     <description>The PAL matrix coefficients value is reported differently depending on container. This test validates for Matroska</description>
                     <rule name="PAL FrameRate 25.000?" value="FrameRate" tracktype="Video" operator="=">25.000</rule>
+                    <policy type="or" name="Are the matrix coefficients BT.470 System B, BT.470 System G?">
                     <rule name="Are the matrix coefficients BT.470 System B, BT.470 System G?" value="matrix_coefficients" tracktype="Video" operator="=">BT.470 System B, BT.470 System G</rule>
+                        <rule name="Are the matrix coefficients BT.470 System B/G?" value="matrix_coefficients" tracktype="Video" operator="=">BT.470 System B/G</rule>
+                    </policy>
                 </policy>
             </policy>
             <policy type="and" name="Has Matroska finished writing?">

--- a/vrecord_policy_ffv1.xml
+++ b/vrecord_policy_ffv1.xml
@@ -20,7 +20,7 @@
                     <description>The PAL matrix coefficients value is reported differently depending on container. This test validates for Matroska</description>
                     <rule name="PAL FrameRate 25.000?" value="FrameRate" tracktype="Video" operator="=">25.000</rule>
                     <policy type="or" name="Are the matrix coefficients BT.470 System B, BT.470 System G?">
-                    <rule name="Are the matrix coefficients BT.470 System B, BT.470 System G?" value="matrix_coefficients" tracktype="Video" operator="=">BT.470 System B, BT.470 System G</rule>
+                        <rule name="Are the matrix coefficients BT.470 System B, BT.470 System G?" value="matrix_coefficients" tracktype="Video" operator="=">BT.470 System B, BT.470 System G</rule>
                         <rule name="Are the matrix coefficients BT.470 System B/G?" value="matrix_coefficients" tracktype="Video" operator="=">BT.470 System B/G</rule>
                     </policy>
                 </policy>


### PR DESCRIPTION
syncing to https://github.com/MediaArea/MediaInfoLib/commit/c75a5f3a864c92ee472b706ba362677f5f0a4697

addresses https://github.com/amiaopensource/vrecord/issues/349