### PR TITLE
add error message when argument is missing

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -235,6 +235,7 @@ while getopts ":herpaxgvI:O:i:" opt ; do
         I) EXTRAINPUTOPTIONS=(${OPTARG}) ;;
         O) EXTRAOUTPUTOPTIONS=(${OPTARG}) ;;
         i) ALT_INPUT="${OPTARG}" ;;
+        :) _report -w "Option -${OPTARG} requires an argument" ; _usage ; exit 1 ;;
         *) _report -w "Error: bad option -${OPTARG}" ; _usage ; exit 1 ;;
     esac
 done


### PR DESCRIPTION
I guess, it’s better to add this.