### PR TITLE
nicer output

### DIFF
--- a/vrecord.1
+++ b/vrecord.1
@@ -1,4 +1,8 @@
 .TH vrecord 1 "https://github.com/amiaopensource/vrecord" "2018\-07\-31" "AMIA Open Source"
+.\" Turn off justification for nroff.
+.if n .ad l
+.\" Turn off hyphenation.
+.nh
 .SH NAME
 vrecord \- An Open\-Source Video Capture Tool for Archivists
 .SH SYNOPSIS


### PR DESCRIPTION
- turn off justification for `nroff`
- turn off hyphenation, because it makes many mistakes in technical documents