### PR TITLE
remove redundant code

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -342,11 +342,7 @@ _master_gui(){
         echo -n -e "\033]0;PRESS Q TO EXIT\007" && man vrecord && echo -n -e "\033]0;\007" && _master_gui
     elif [[ "${DOCUMENTATION_BUTTON}" = 1 ]] ; then
         open https://github.com/amiaopensource/vrecord#vrecord-documentation && _master_gui
-    # db = default button, set to exit
-    elif [[ "${db}" = 1 ]] ; then
-        echo "Exiting Vrecord. Goodbye!" && exit 0
     else
-        # catch instance when the window is closed with no button pressed
         echo "Exiting Vrecord. Goodbye!" && exit 0
     fi
     if [[ -f "${PASHUA_CONFIGFILE}" ]] ; then


### PR DESCRIPTION
The `else` includes the `previous elif [[ "${db}" = 1 ]]` as well.