### PR TITLE
use sed to create valid dir path variable

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1243,6 +1243,7 @@ done
 if [[ ! -d "${DIR}" ]] ; then
     _report -q -n "Enter Directory: "
     read DIR
+    DIR="$(echo "${DIR}" | sed "s/^['\"]\(.*\).$/\1/")"
     if [[ ! -d "${DIR}" ]] ; then
         _report -w "Error: Not a valid directory"
         exit 1
@@ -1253,6 +1254,7 @@ if [[ ! -d "${LOGDIR}" ]] ; then
     if [[ ! -d "${DIR}" ]] ; then
         _report -q -n "Enter Directory for Auxiliary Files (If blank will default to recording directory): "
         read LOGDIR
+        LOGDIR="$(echo "${LOGDIR}" | sed "s/^['\"]\(.*\).$/\1/")"
     else
         LOGDIR="${DIR}"
     fi


### PR DESCRIPTION
This seeks to fix an issue with the current method of checking if directories input via CLI exist.
The current check `[[ ! -d "${DIR}" ]]`  (at least on Linux) will fail if there are quotes around the filepath that the user inputs.

![image](https://user-images.githubusercontent.com/12941699/54052499-64e45c80-4199-11e9-8bb5-85798ea024fa.png)


Since one of the most common methods of getting a path into the terminal is to drag the folder in, which automatically adds these quotes, it seems useful from a user side to automatically strip them for the variable that is used in the directory check.