### PR TITLE
Update linux_installation.md

### DIFF
--- a/Resources/Documentation/linux_installation.md
+++ b/Resources/Documentation/linux_installation.md
@@ -44,7 +44,7 @@ There are many possible ways to install the various dependencies of Vrecord on L
    - `brew tap amiaopensource/amiaos`
 
 ## Install additional vrecord dependencies via Homebrew
-* `brew install decklinksdk && brew install ffmpegdecklink --with-libiec61883 && brew install gtkdialog`
+* `brew install decklinksdk && brew install ffmpegdecklink --with-iec61883 && brew install gtkdialog`
 * `brew install --ignore-dependencies vrecord`
 
 ## Fix conflicting SDL2 dependencies


### PR DESCRIPTION
It seems the option for enabling DV devices  with ffmpegdecklink changed to --with-iec61883

`~$ brew install ffmpegdecklink --help
Usage: brew install [options] formula

[...]
        **--with-iec61883              ffmpegdecklink: Enable DV device (Linux)**
[...]
    -h, --help                       Show this message.`