### PR TITLE
adds an avfoundation input option to vrecord

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -577,8 +577,8 @@ _passthrough_mode(){
     _set_ffplay_options
     if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then
         _check_mpv
-        "${FFMPEG_DECKLINK}" -nostats "${GRAB_DECKLINK[@]}" 2> >(tee /tmp/vrecord_input.log 1>&2) \
-        "${PIPE_DECKLINK[@]}" | \
+        "${FFMPEG_DECKLINK}" -nostats "${GRAB_INPUT[@]}" 2> >(tee /tmp/vrecord_input.log 1>&2) \
+        "${PIPE_OUTPUT[@]}" | \
         mpv "${MPVOPTS[@]}" --title="${WINDOW_NAME}" -
     else
         "${FFPLAY_DECKLINK}" "${FFPLAY_OPTIONS[@]}" 2> >(tee /tmp/vrecord_input.log 1>&2)
@@ -598,7 +598,7 @@ _audiopassthrough_mode(){
 [abcde1][a1]overlay=10:10[vo]"
     echo "ESC quit" > ~/.config/mpv/input.conf
     _check_mpv
-    "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_DECKLINK[@]}" "${PIPE_DECKLINK[@]}" 2> /tmp/vrecord_input.log | \
+    "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> /tmp/vrecord_input.log | \
         mpv - --title="${WINDOW_NAME}" -lavfi-complex "${PLAYBACKFILTER}"
     _gui_return
 }
@@ -1164,30 +1164,30 @@ MIDDLEOPTIONS+=(${EXTRAOUTPUTOPTIONS[@]})
 # set up input and playback
 _set_up_drawtext
 if [[ "$VERBOSE" = "true" ]] ; then
-    GRAB_DECKLINK=(-loglevel debug)
+    GRAB_INPUT=(-loglevel debug)
     _report -wt "When running vrecord in verbose mode, avoid using Visual + Numerical option."
 else
-    GRAB_DECKLINK=(-loglevel info)
+    GRAB_INPUT=(-loglevel info)
 fi
 if [[ -n "${ALT_INPUT}" ]] ; then
-    GRAB_DECKLINK+=(-i "${ALT_INPUT}")
 else
+    GRAB_INPUT+=(-i "${ALT_INPUT}")
     _get_decklink_inputs
-    GRAB_DECKLINK+=(-f decklink)
-    GRAB_DECKLINK+=(-draw_bars 0)
-    GRAB_DECKLINK+=(-audio_input "${AUDIO_INPUT}")
-    GRAB_DECKLINK+=(-video_input "${VIDEO_INPUT}")
-    GRAB_DECKLINK+=(-format_code "${STANDARD}")
-    GRAB_DECKLINK+=(-channels 8)
-    GRAB_DECKLINK+=(-audio_depth 32)
-    GRAB_DECKLINK+=(-raw_format "${PIXEL_FORMAT}")
-    GRAB_DECKLINK+=("${EXTRAINPUTOPTIONS[@]}")
-    GRAB_DECKLINK+=(-i "${FIRST_DECKLINK_INPUT}")
+    GRAB_INPUT+=(-f decklink)
+    GRAB_INPUT+=(-draw_bars 0)
+    GRAB_INPUT+=(-audio_input "${AUDIO_INPUT}")
+    GRAB_INPUT+=(-video_input "${VIDEO_INPUT}")
+    GRAB_INPUT+=(-format_code "${STANDARD}")
+    GRAB_INPUT+=(-channels 8)
+    GRAB_INPUT+=(-audio_depth 32)
+    GRAB_INPUT+=(-raw_format "${PIXEL_FORMAT}")
+    GRAB_INPUT+=("${EXTRAINPUTOPTIONS[@]}")
+    GRAB_INPUT+=(-i "${FIRST_DECKLINK_INPUT}")
 fi
 
 if [[ "${TIMECODE_SCAN}" = 1 ]] ; then
     for timecode_type in "${TIMECODE_OPTIONS[@]}" ; do
-        tc_value="$("${FFPROBE_DECKLINK}" "${GRAB_DECKLINK[@]}" -timecode_format "${timecode_type}" -show_entries stream_tags=timecode -of default=nw=1:nk=1 2>/dev/null)"
+        tc_value="$("${FFPROBE_DECKLINK}" "${GRAB_INPUT[@]}" -timecode_format "${timecode_type}" -show_entries stream_tags=timecode -of default=nw=1:nk=1 2>/dev/null)"
         if [[ -z "${tc_value}" ]] ; then
             tc_value="none"
         fi
@@ -1195,12 +1195,12 @@ if [[ "${TIMECODE_SCAN}" = 1 ]] ; then
     done
     _edit_prefs
 fi
-PIPE_DECKLINK=(-c copy)
-PIPE_DECKLINK+=(-map 0)
-PIPE_DECKLINK+=(-f matroska)
-PIPE_DECKLINK+=(-write_crc32 0)
-PIPE_DECKLINK+=(-live true)
-PIPE_DECKLINK+=(-)
+PIPE_OUTPUT=(-c copy)
+PIPE_OUTPUT+=(-map 0)
+PIPE_OUTPUT+=(-f matroska)
+PIPE_OUTPUT+=(-write_crc32 0)
+PIPE_OUTPUT+=(-live true)
+PIPE_OUTPUT+=(-)
 WINDOW_NAME="mode:${RUNTYPE} - video:'${VIDEO_INPUT}' audio:'${AUDIO_INPUT}' - to end recording press q, esc, or close video window"
 
 _set_ffplay_options(){
@@ -1209,7 +1209,7 @@ _set_ffplay_options(){
     FFPLAY_OPTIONS+=(-stats)
     FFPLAY_OPTIONS+=(-autoexit)
     if [[ "${RUNTYPE}" = "passthrough" ]] ; then
-        FFPLAY_OPTIONS+=("${GRAB_DECKLINK[@]}")
+        FFPLAY_OPTIONS+=("${GRAB_INPUT[@]}")
     else
         FFPLAY_OPTIONS+=(-i -)
     fi
@@ -1388,11 +1388,11 @@ _report -d "Close the playback window to stop recording."
 
 # vrecord process!
 RECORD_COMMAND=("${FFMPEG_DECKLINK}")
-RECORD_COMMAND+=(-nostdin -nostats "${INPUTOPTIONS[@]}" "${GRAB_DECKLINK[@]}")
 RECORD_COMMAND+=(-metadata:s:v:0 encoder="${VIDEOCODECNAME}" "${MIDDLEOPTIONS[@]}")
+RECORD_COMMAND+=(-nostdin -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}")
 RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
 RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
-RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_DECKLINK[@]}")
+RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
 _writeingestlog "FFmpeg command" "${RECORD_COMMAND[@]}"
 _set_ffplay_options
 if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then

--- a/vrecord
+++ b/vrecord
@@ -314,6 +314,23 @@ DECKLINK_INPUT_GUI="
                 $(_gtk_vbox_list "AUDIO_CODEC_CHOICE"       "Select Audio Codec"            "${AUDIO_CODEC_OPTIONS[@]}")
             </hbox>
         </frame>
+    </vbox>
+</frame>"
+
+unset AVFOUNDATION_DEVICES
+while read avf_device ; do
+    AVFOUNDATION_DEVICES+=("${avf_device}")
+done < <("${FFMPEG_DECKLINK}" -nostdin -hide_banner -f avfoundation -list_devices 1 -i dummy 2>&1 | grep -o "\[[0-9]\].*" | cut -d " " -f2-)
+
+AVFOUNDATION_INPUT_GUI="
+<frame AVFoundation input options>
+    <vbox>
+        <hbox space-expand=\"true\">
+            $(_gtk_vbox_list "AVF_INPUT_CHOICE"         "Select a DV Device"           "${AVFOUNDATION_DEVICES[@]}")
+        </hbox>
+    </vbox>
+</frame>"
+
   export MAIN_DIALOG="<window title=\"vrecord configuration\">
     <vbox>
         <text>
@@ -322,6 +339,7 @@ DECKLINK_INPUT_GUI="
         <frame Input Options>
         <notebook page=\"${DEVICE_INPUT_CHOICE}\" tab-labels=\"Decklink|DV|\">
             ${DECKLINK_INPUT_GUI}
+            ${AVFOUNDATION_INPUT_GUI}
             <variable>DEVICE_INPUT_CHOICE</variable>
         </notebook>
         </frame>
@@ -509,6 +527,7 @@ _edit_mode(){
         fi
         echo "Variables set:"
         echo "  DEVICE_INPUT_CHOICE = ${DEVICE_INPUT_CHOICE}"
+        echo "  AVF_INPUT_CHOICE = ${AVF_INPUT_CHOICE}"
         echo "  DIR = ${DIR}"
         echo "  LOGDIR = ${LOGDIR}"
         echo "  CONTAINER_CHOICE = ${CONTAINER_CHOICE}"
@@ -552,7 +571,8 @@ _edit_mode(){
             echo "# Set these variables to a valid option or leave as empty quotes (like \"\") to request each run."
             for COMMENT_LINE in DEVICE_INPUT_CHOICE VIDEO_INPUT_CHOICE AUDIO_INPUT_CHOICE CONTAINER_CHOICE VIDEO_CODEC_CHOICE FFV1_SLICE_CHOICE AUDIO_CODEC_CHOICE\
             VIDEO_BIT_DEPTH_CHOICE AUDIO_MAPPING_CHOICE TIMECODE_CHOICE STANDARD_CHOICE QCTOOLSXML_CHOICE FRAMEMD5_CHOICE \
-            EMBED_LOGS_CHOICE PLAYBACKVIEW_CHOICE PLAYBACKVIEW_CHOICE_PASS DIR LOGDIR INVERT_PHASE DURATION PREFIX USER_SUFFIX NO_SUFFIX TECHNICIAN ; do
+            EMBED_LOGS_CHOICE PLAYBACKVIEW_CHOICE PLAYBACKVIEW_CHOICE_PASS DIR LOGDIR INVERT_PHASE DURATION PREFIX USER_SUFFIX NO_SUFFIX TECHNICIAN \
+            AVF_INPUT_CHOICE ; do
                 echo "${COMMENT_LINE}=\"${!COMMENT_LINE}\""
             done
         } > "${CONFIG_FILE}"
@@ -1191,6 +1211,13 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     GRAB_INPUT+=(-raw_format "${PIXEL_FORMAT}")
     GRAB_INPUT+=("${EXTRAINPUTOPTIONS[@]}")
     GRAB_INPUT+=(-i "${FIRST_DECKLINK_INPUT}")
+elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
+    GRAB_INPUT+=(-f avfoundation)
+    GRAB_INPUT+=(-capture_raw_data true)
+    GRAB_INPUT+=(-i "${AVF_INPUT_CHOICE}")
+    MIDDLEOPTIONS+=(-c copy -map 0)
+    EXTENSION="dv"
+    FORMAT="dv"
 fi
 
 if [[ "${TIMECODE_SCAN}" = 1 ]] ; then

--- a/vrecord
+++ b/vrecord
@@ -1398,8 +1398,11 @@ _report -d "Close the playback window to stop recording."
 
 # vrecord process!
 RECORD_COMMAND=("${FFMPEG_DECKLINK}")
-RECORD_COMMAND+=(-metadata:s:v:0 encoder="${VIDEOCODECNAME}" "${MIDDLEOPTIONS[@]}")
 RECORD_COMMAND+=(-nostdin -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}")
+if [[ -n "${VIDEOCODECNAME}" ]] ; then
+    MIDDLEOPTIONS+=(-metadata:s:v:0 encoder="${VIDEOCODECNAME}")
+fi
+RECORD_COMMAND+=("${MIDDLEOPTIONS[@]}")
 if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     # DEVICE_INPUT_CHOICE=0 is decklink, other DEVICE_INPUT_CHOICE values don't yet use such filtering
 RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")

--- a/vrecord
+++ b/vrecord
@@ -289,13 +289,9 @@ _edit_prefs() {
     fi
   }
 
-  export MAIN_DIALOG="<window title=\"vrecord configuration\">
+DECKLINK_INPUT_GUI="
+<frame Decklink input options>
     <vbox>
-        <text>
-            <label>Set file recording options.</label>
-        </text>
-        <frame Decklink input options>
-            <vbox>
                 <hbox space-expand=\"true\">
                     $(_gtk_vbox_list "VIDEO_INPUT_CHOICE"       "Select Video Input"            "${VIDEO_INPUT_OPTIONS[@]}")
                     $(_gtk_vbox_list "AUDIO_INPUT_CHOICE"       "Select Audio Input"            "${AUDIO_INPUT_OPTIONS[@]}")
@@ -309,8 +305,6 @@ _edit_prefs() {
                     <default>false</default>
                     <variable>INVERT_PHASE</variable>
                 </checkbox>
-            </vbox>
-        </frame>
         <frame Output file options>
             <hbox space-expand=\"true\">
                 $(_gtk_vbox_list "EMBED_LOGS_CHOICE"        "Embed digitization logs in video file (Matroska ONLY)" "${EMBED_LOGS_OPTIONS[@]}")
@@ -319,6 +313,17 @@ _edit_prefs() {
                 $(_gtk_vbox_list "VIDEO_CODEC_CHOICE"       "Select Video Codec"            "${VIDEO_CODEC_OPTIONS[@]}")
                 $(_gtk_vbox_list "AUDIO_CODEC_CHOICE"       "Select Audio Codec"            "${AUDIO_CODEC_OPTIONS[@]}")
             </hbox>
+        </frame>
+  export MAIN_DIALOG="<window title=\"vrecord configuration\">
+    <vbox>
+        <text>
+            <label>Set file recording options.</label>
+        </text>
+        <frame Input Options>
+        <notebook page=\"${DEVICE_INPUT_CHOICE}\" tab-labels=\"Decklink|DV|\">
+            ${DECKLINK_INPUT_GUI}
+            <variable>DEVICE_INPUT_CHOICE</variable>
+        </notebook>
         </frame>
         <hbox>
             <frame Playback options>
@@ -503,6 +508,7 @@ _edit_mode(){
             echo "As auxiliary files directory was left blank, logs will be written to recording directory at ${DIR}."
         fi
         echo "Variables set:"
+        echo "  DEVICE_INPUT_CHOICE = ${DEVICE_INPUT_CHOICE}"
         echo "  DIR = ${DIR}"
         echo "  LOGDIR = ${LOGDIR}"
         echo "  CONTAINER_CHOICE = ${CONTAINER_CHOICE}"
@@ -544,7 +550,7 @@ _edit_mode(){
         # write config file
         {
             echo "# Set these variables to a valid option or leave as empty quotes (like \"\") to request each run."
-            for COMMENT_LINE in VIDEO_INPUT_CHOICE AUDIO_INPUT_CHOICE CONTAINER_CHOICE VIDEO_CODEC_CHOICE FFV1_SLICE_CHOICE AUDIO_CODEC_CHOICE\
+            for COMMENT_LINE in DEVICE_INPUT_CHOICE VIDEO_INPUT_CHOICE AUDIO_INPUT_CHOICE CONTAINER_CHOICE VIDEO_CODEC_CHOICE FFV1_SLICE_CHOICE AUDIO_CODEC_CHOICE\
             VIDEO_BIT_DEPTH_CHOICE AUDIO_MAPPING_CHOICE TIMECODE_CHOICE STANDARD_CHOICE QCTOOLSXML_CHOICE FRAMEMD5_CHOICE \
             EMBED_LOGS_CHOICE PLAYBACKVIEW_CHOICE PLAYBACKVIEW_CHOICE_PASS DIR LOGDIR INVERT_PHASE DURATION PREFIX USER_SUFFIX NO_SUFFIX TECHNICIAN ; do
                 echo "${COMMENT_LINE}=\"${!COMMENT_LINE}\""
@@ -1137,12 +1143,14 @@ _review_option(){
     fi
 }
 
+if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
 _review_option "VIDEO_INPUT_CHOICE" "Which video input are you using?" "${VIDEO_INPUT_OPTIONS[@]}"
 _review_option "AUDIO_INPUT_CHOICE" "Which audio input are you using?" "${AUDIO_INPUT_OPTIONS[@]}"
 _review_option "VIDEO_BIT_DEPTH_CHOICE" "Which video bit depth?" "${VIDEO_BITDEPTH_OPTIONS[@]}"
 _review_option "AUDIO_MAPPING_CHOICE" "Which audio mapping?" "${CHANNEL_MAPPING_OPTIONS[@]}"
 _review_option "TIMECODE_CHOICE" "Which timecode format?" "${TIMECODE_OPTIONS[@]}"
 _review_option "STANDARD_CHOICE" "Which television STANDARD?" "${STANDARD_OPTIONS[@]}"
+fi
 if [[ "${CORE_COUNT}" -le 2 && "${RUNTYPE}" = "record" ]] ; then
     _report -w "Since this computer has only ${CORE_COUNT} cores, the playback will display only half of the frames to reduce CPU. This will not impact the recording."
     PLAYBACK_FILTER_ADJUSTMENT="select=not(mod(n\,2)),"
@@ -1170,8 +1178,8 @@ else
     GRAB_INPUT=(-loglevel info)
 fi
 if [[ -n "${ALT_INPUT}" ]] ; then
-else
     GRAB_INPUT+=(-i "${ALT_INPUT}")
+elif [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     _get_decklink_inputs
     GRAB_INPUT+=(-f decklink)
     GRAB_INPUT+=(-draw_bars 0)
@@ -1272,12 +1280,14 @@ if [[ ! -d "${LOGDIR}" ]] ; then
     fi
 fi
 
+if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
 _review_option "CONTAINER_CHOICE" "Which audiovisual container format?" "${CONTAINER_OPTIONS[@]}"
 _review_option "VIDEO_CODEC_CHOICE" "Which video codec?" "${VIDEO_CODEC_OPTIONS[@]}"
 if [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
     _review_option -n "FFV1_SLICE_CHOICE" "FFV1 Slice Count?" "${FFV1_SLICE_OPTIONS[@]}"
 fi
 _review_option "AUDIO_CODEC_CHOICE" "Which audio codec?" "${AUDIO_CODEC_OPTIONS[@]}"
+fi
 
 # Check for user suffix to override automatic settings
 
@@ -1390,7 +1400,10 @@ _report -d "Close the playback window to stop recording."
 RECORD_COMMAND=("${FFMPEG_DECKLINK}")
 RECORD_COMMAND+=(-metadata:s:v:0 encoder="${VIDEOCODECNAME}" "${MIDDLEOPTIONS[@]}")
 RECORD_COMMAND+=(-nostdin -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}")
+if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
+    # DEVICE_INPUT_CHOICE=0 is decklink, other DEVICE_INPUT_CHOICE values don't yet use such filtering
 RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
+fi
 RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
 RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
 _writeingestlog "FFmpeg command" "${RECORD_COMMAND[@]}"
@@ -1523,6 +1536,7 @@ if [[ "${BUFFER_OVERRUN}" -gt 0 ]] ; then
     _writeingestlog "Decklink input buffer overrun" "Yes"
 fi
 
+if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
 # policy checks with mediaconch
 if [[ "${VIDEO_CODEC_CHOICE}" = "Uncompressed Video" ]] ; then
     _report -d "Checking file conformance against uncompressed video policy..."
@@ -1559,4 +1573,5 @@ if [[ "${CONTAINER_CHOICE}" = "Matroska" ]] && [[ "${EMBED_LOGS_CHOICE}" = "Yes"
         mkvpropedit "${VRECORD_OUTPUT}" --attachment-description "QCTools report from vrecord capture process (zipped XML)" --add-attachment "${QCXML}"
     fi
     _report -d "Vrecord is done attaching logs to your Matroska file!"
+fi
 fi

--- a/vrecord
+++ b/vrecord
@@ -292,19 +292,19 @@ _edit_prefs() {
 DECKLINK_INPUT_GUI="
 <frame Decklink input options>
     <vbox>
-                <hbox space-expand=\"true\">
-                    $(_gtk_vbox_list "VIDEO_INPUT_CHOICE"       "Select Video Input"            "${VIDEO_INPUT_OPTIONS[@]}")
-                    $(_gtk_vbox_list "AUDIO_INPUT_CHOICE"       "Select Audio Input"            "${AUDIO_INPUT_OPTIONS[@]}")
-                    $(_gtk_vbox_list "AUDIO_MAPPING_CHOICE"     "Select Audio Channel Mapping"  "${CHANNEL_MAPPING_OPTIONS[@]}" )
-                    $(_gtk_vbox_list "STANDARD_CHOICE"          "Select Standard"               "${STANDARD_OPTIONS[@]}")
-                    $(_gtk_vbox_list "VIDEO_BIT_DEPTH_CHOICE"   "Select Video Bit Depth"        "${VIDEO_BITDEPTH_OPTIONS[@]}")
-                    $(_gtk_vbox_list "TIMECODE_CHOICE"          "Select timecode format"        "${TIMECODE_OPTIONS[@]}")
-                </hbox>
-                <checkbox>
-                    <label>Invert Second Channel of Audio (WARNING: Do not use this option unless required)</label>
-                    <default>false</default>
-                    <variable>INVERT_PHASE</variable>
-                </checkbox>
+        <hbox space-expand=\"true\">
+            $(_gtk_vbox_list "VIDEO_INPUT_CHOICE"       "Select Video Input"            "${VIDEO_INPUT_OPTIONS[@]}")
+            $(_gtk_vbox_list "AUDIO_INPUT_CHOICE"       "Select Audio Input"            "${AUDIO_INPUT_OPTIONS[@]}")
+            $(_gtk_vbox_list "AUDIO_MAPPING_CHOICE"     "Select Audio Channel Mapping"  "${CHANNEL_MAPPING_OPTIONS[@]}" )
+            $(_gtk_vbox_list "STANDARD_CHOICE"          "Select Standard"               "${STANDARD_OPTIONS[@]}")
+            $(_gtk_vbox_list "VIDEO_BIT_DEPTH_CHOICE"   "Select Video Bit Depth"        "${VIDEO_BITDEPTH_OPTIONS[@]}")
+            $(_gtk_vbox_list "TIMECODE_CHOICE"          "Select timecode format"        "${TIMECODE_OPTIONS[@]}")
+        </hbox>
+        <checkbox>
+            <label>Invert Second Channel of Audio (WARNING: Do not use this option unless required)</label>
+            <default>false</default>
+            <variable>INVERT_PHASE</variable>
+        </checkbox>
         <frame Output file options>
             <hbox space-expand=\"true\">
                 $(_gtk_vbox_list "EMBED_LOGS_CHOICE"        "Embed digitization logs in video file (Matroska ONLY)" "${EMBED_LOGS_OPTIONS[@]}")
@@ -1164,12 +1164,12 @@ _review_option(){
 }
 
 if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
-_review_option "VIDEO_INPUT_CHOICE" "Which video input are you using?" "${VIDEO_INPUT_OPTIONS[@]}"
-_review_option "AUDIO_INPUT_CHOICE" "Which audio input are you using?" "${AUDIO_INPUT_OPTIONS[@]}"
-_review_option "VIDEO_BIT_DEPTH_CHOICE" "Which video bit depth?" "${VIDEO_BITDEPTH_OPTIONS[@]}"
-_review_option "AUDIO_MAPPING_CHOICE" "Which audio mapping?" "${CHANNEL_MAPPING_OPTIONS[@]}"
-_review_option "TIMECODE_CHOICE" "Which timecode format?" "${TIMECODE_OPTIONS[@]}"
-_review_option "STANDARD_CHOICE" "Which television STANDARD?" "${STANDARD_OPTIONS[@]}"
+    _review_option "VIDEO_INPUT_CHOICE" "Which video input are you using?" "${VIDEO_INPUT_OPTIONS[@]}"
+    _review_option "AUDIO_INPUT_CHOICE" "Which audio input are you using?" "${AUDIO_INPUT_OPTIONS[@]}"
+    _review_option "VIDEO_BIT_DEPTH_CHOICE" "Which video bit depth?" "${VIDEO_BITDEPTH_OPTIONS[@]}"
+    _review_option "AUDIO_MAPPING_CHOICE" "Which audio mapping?" "${CHANNEL_MAPPING_OPTIONS[@]}"
+    _review_option "TIMECODE_CHOICE" "Which timecode format?" "${TIMECODE_OPTIONS[@]}"
+    _review_option "STANDARD_CHOICE" "Which television STANDARD?" "${STANDARD_OPTIONS[@]}"
 fi
 if [[ "${CORE_COUNT}" -le 2 && "${RUNTYPE}" = "record" ]] ; then
     _report -w "Since this computer has only ${CORE_COUNT} cores, the playback will display only half of the frames to reduce CPU. This will not impact the recording."
@@ -1311,12 +1311,12 @@ if [[ ! -d "${LOGDIR}" ]] ; then
 fi
 
 if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
-_review_option "CONTAINER_CHOICE" "Which audiovisual container format?" "${CONTAINER_OPTIONS[@]}"
-_review_option "VIDEO_CODEC_CHOICE" "Which video codec?" "${VIDEO_CODEC_OPTIONS[@]}"
-if [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
-    _review_option -n "FFV1_SLICE_CHOICE" "FFV1 Slice Count?" "${FFV1_SLICE_OPTIONS[@]}"
-fi
-_review_option "AUDIO_CODEC_CHOICE" "Which audio codec?" "${AUDIO_CODEC_OPTIONS[@]}"
+    _review_option "CONTAINER_CHOICE" "Which audiovisual container format?" "${CONTAINER_OPTIONS[@]}"
+    _review_option "VIDEO_CODEC_CHOICE" "Which video codec?" "${VIDEO_CODEC_OPTIONS[@]}"
+    if [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
+        _review_option -n "FFV1_SLICE_CHOICE" "FFV1 Slice Count?" "${FFV1_SLICE_OPTIONS[@]}"
+    fi
+    _review_option "AUDIO_CODEC_CHOICE" "Which audio codec?" "${AUDIO_CODEC_OPTIONS[@]}"
 fi
 
 # Check for user suffix to override automatic settings
@@ -1435,7 +1435,7 @@ fi
 RECORD_COMMAND+=("${MIDDLEOPTIONS[@]}")
 if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     # DEVICE_INPUT_CHOICE=0 is decklink, other DEVICE_INPUT_CHOICE values don't yet use such filtering
-RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
+    RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
 fi
 RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
 RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
@@ -1570,41 +1570,41 @@ if [[ "${BUFFER_OVERRUN}" -gt 0 ]] ; then
 fi
 
 if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
-# policy checks with mediaconch
-if [[ "${VIDEO_CODEC_CHOICE}" = "Uncompressed Video" ]] ; then
-    _report -d "Checking file conformance against uncompressed video policy..."
-    STATUS=$(mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_uncompressed.xml" "${VRECORD_OUTPUT}" | xmlstarlet sel -N mc="https://mediaarea.net/mediaconch" -t -v mc:MediaConch/mc:media/mc:policy/@outcome -n)
-    if [[ "$STATUS" = "pass" ]] ; then
-        _report -dt "File passed policy check for uncompressed video."
-    elif [[ "$STATUS" = "fail" ]] ; then
-        _report -wt "File did not pass vrecord policy check for uncompressed video and may not conform to digital preservation standards. Try another file?"
-        mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_uncompressed.xml" "${VRECORD_OUTPUT}" | xmlstarlet fo > "${DIR}/${FULL_OUTPUT_ID}_mediaconchreport.xml"
-        _report -wt "See ${DIR}/${ID}${SUFFIX}_mediaconchreport.xml for a full MediaConch policy report."
-    else
-        mediaconch -p "${RESOURCE_PATH}/vrecord_policy_uncompressed.xml" "${VRECORD_OUTPUT}"
+  # policy checks with mediaconch
+    if [[ "${VIDEO_CODEC_CHOICE}" = "Uncompressed Video" ]] ; then
+        _report -d "Checking file conformance against uncompressed video policy..."
+        STATUS=$(mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_uncompressed.xml" "${VRECORD_OUTPUT}" | xmlstarlet sel -N mc="https://mediaarea.net/mediaconch" -t -v mc:MediaConch/mc:media/mc:policy/@outcome -n)
+        if [[ "$STATUS" = "pass" ]] ; then
+            _report -dt "File passed policy check for uncompressed video."
+        elif [[ "$STATUS" = "fail" ]] ; then
+            _report -wt "File did not pass vrecord policy check for uncompressed video and may not conform to digital preservation standards. Try another file?"
+            mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_uncompressed.xml" "${VRECORD_OUTPUT}" | xmlstarlet fo > "${DIR}/${FULL_OUTPUT_ID}_mediaconchreport.xml"
+            _report -wt "See ${DIR}/${ID}${SUFFIX}_mediaconchreport.xml for a full MediaConch policy report."
+        else
+            mediaconch -p "${RESOURCE_PATH}/vrecord_policy_uncompressed.xml" "${VRECORD_OUTPUT}"
+        fi
+    elif [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
+        _report -d "Checking file conformance against FFV1 video policy..."
+        STATUS=$(mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_ffv1.xml" "${VRECORD_OUTPUT}" | xmlstarlet sel -N mc="https://mediaarea.net/mediaconch" -t -v mc:MediaConch/mc:media/mc:policy/@outcome -n)
+        if [[ "${STATUS}" = "pass" ]] ; then
+            _report -dt "File passed policy check for FFV1 video."
+        elif [[ "$STATUS" = "fail" ]] ; then
+            _report -wt "File did not pass vrecord policy check for FFV1 video and may not conform to digital preservation standards. Try another file?"
+            mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_ffv1.xml" "${VRECORD_OUTPUT}" | xmlstarlet fo > "${DIR}/${FULL_OUTPUT_ID}_mediaconchreport.xml"
+            _report -wt "See ${DIR}/${ID}${SUFFIX}_mediaconchreport.xml for a full MediaConch policy report."
+        else
+            mediaconch -p "${RESOURCE_PATH}/vrecord_policy_ffv1.xml" "${VRECORD_OUTPUT}"
+        fi
     fi
-elif [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
-    _report -d "Checking file conformance against FFV1 video policy..."
-    STATUS=$(mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_ffv1.xml" "${VRECORD_OUTPUT}" | xmlstarlet sel -N mc="https://mediaarea.net/mediaconch" -t -v mc:MediaConch/mc:media/mc:policy/@outcome -n)
-    if [[ "${STATUS}" = "pass" ]] ; then
-        _report -dt "File passed policy check for FFV1 video."
-    elif [[ "$STATUS" = "fail" ]] ; then
-        _report -wt "File did not pass vrecord policy check for FFV1 video and may not conform to digital preservation standards. Try another file?"
-        mediaconch -fx -p "${RESOURCE_PATH}/vrecord_policy_ffv1.xml" "${VRECORD_OUTPUT}" | xmlstarlet fo > "${DIR}/${FULL_OUTPUT_ID}_mediaconchreport.xml"
-        _report -wt "See ${DIR}/${ID}${SUFFIX}_mediaconchreport.xml for a full MediaConch policy report."
-    else
-        mediaconch -p "${RESOURCE_PATH}/vrecord_policy_ffv1.xml" "${VRECORD_OUTPUT}"
-    fi
-fi
 
-# embed logs in Matroska files
-if [[ "${CONTAINER_CHOICE}" = "Matroska" ]] && [[ "${EMBED_LOGS_CHOICE}" = "Yes" ]] ; then
-    _report -d "Vrecord is attaching logs to your Matroska file:"
-    mkvpropedit "${VRECORD_OUTPUT}" --attachment-description "Capture options selected by user during vrecord process" --add-attachment "${INGESTLOG}"
-    mkvpropedit "${VRECORD_OUTPUT}" --attachment-description "Full FFmpeg output from vrecord capture process" --add-attachment "${FULL_CAPTURE_LOG}"
-    if [[ "${QCTOOLSXML_CHOICE}" = "Yes" ]] ; then
-        mkvpropedit "${VRECORD_OUTPUT}" --attachment-description "QCTools report from vrecord capture process (zipped XML)" --add-attachment "${QCXML}"
+    # embed logs in Matroska files
+    if [[ "${CONTAINER_CHOICE}" = "Matroska" ]] && [[ "${EMBED_LOGS_CHOICE}" = "Yes" ]] ; then
+        _report -d "Vrecord is attaching logs to your Matroska file:"
+        mkvpropedit "${VRECORD_OUTPUT}" --attachment-description "Capture options selected by user during vrecord process" --add-attachment "${INGESTLOG}"
+        mkvpropedit "${VRECORD_OUTPUT}" --attachment-description "Full FFmpeg output from vrecord capture process" --add-attachment "${FULL_CAPTURE_LOG}"
+        if [[ "${QCTOOLSXML_CHOICE}" = "Yes" ]] ; then
+            mkvpropedit "${VRECORD_OUTPUT}" --attachment-description "QCTools report from vrecord capture process (zipped XML)" --add-attachment "${QCXML}"
+        fi
+        _report -d "Vrecord is done attaching logs to your Matroska file!"
     fi
-    _report -d "Vrecord is done attaching logs to your Matroska file!"
-fi
 fi

--- a/vrecord
+++ b/vrecord
@@ -1218,6 +1218,9 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     MIDDLEOPTIONS+=(-c copy -map 0)
     EXTENSION="dv"
     FORMAT="dv"
+else
+    _report "Input unknown"
+    exit 1
 fi
 
 if [[ "${TIMECODE_SCAN}" = 1 ]] ; then


### PR DESCRIPTION
supports capture from DV devices. The options are very limited to focus on piping the dv stream from the input to output, so the interface is a lot simpler than that for decklink. Rewrapping to a container could be added as a post-process later.