### PR TITLE
edit filter

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -900,7 +900,7 @@ _lookup_choice(){
         "Broadcast Range Visual")
             PLAYBACKFILTER="\
 ${PLAYBACK_FILTER_ADJUSTMENT}split=5[a][b][c][d][e];\
-[a]copy${TIMECODE_OVERLAY}[a1];\
+[a]${RECORDINGFILTER}${TIMECODE_OVERLAY}[a1];\
 [b]field=top,${WAVEFORM_FILTER}[b1];\
 [c]field=bottom,${WAVEFORM_FILTER}[c1];\
 [d]${VECTORSCOPE_FILTER}[d1];\
@@ -909,7 +909,7 @@ ${PLAYBACK_FILTER_ADJUSTMENT}split=5[a][b][c][d][e];\
         "Full Range Visual")
             PLAYBACKFILTER="\
 ${PLAYBACK_FILTER_ADJUSTMENT}split=5[a][b][c][d][e];\
-[a]copy${TIMECODE_OVERLAY}[a1];\
+[a]${RECORDINGFILTER}${TIMECODE_OVERLAY}[a1];\
 [b]field=top,${WAVEFORM_FILTER}[b1];\
 [c]field=bottom,${WAVEFORM_FILTER}[c1];\
 [d]${VECTORSCOPE_FILTER}[d1];\
@@ -918,7 +918,7 @@ ${PLAYBACK_FILTER_ADJUSTMENT}split=5[a][b][c][d][e];\
       "Visual + Numerical")
           PLAYBACKFILTER="\
 ${PLAYBACK_FILTER_ADJUSTMENT}split=6[a][b][c][d][e][f];\
-[a]copy${TIMECODE_OVERLAY}[a1];\
+[a]${RECORDINGFILTER}${TIMECODE_OVERLAY}[a1];\
 [b]field=top,${WAVEFORM_FILTER}[b1];\
 [c]field=bottom,${WAVEFORM_FILTER}[c1];\
 [d]${VECTORSCOPE_FILTER}[d1];\


### PR DESCRIPTION
Currently certain preview modes do not represent the actual aspect ratio that is being captured to file. Unfiltered view seems to get it right, but the ffplay views that utilize the longer filter chain don't seem to be passing the parameters that are set via NTSC or PAL choices. (See examples below). This PR applies upstream settings into the filter chain.

Broadcast range visual:
![image](https://user-images.githubusercontent.com/12941699/69999204-ef7da080-150c-11ea-94b1-ab5b0a148f29.png)

Unfiltered:
![image](https://user-images.githubusercontent.com/12941699/69999299-2bb10100-150d-11ea-9f74-4bf7b0f54c07.png)

Broadcast range visual (this branch):
![image](https://user-images.githubusercontent.com/12941699/69999233-03290700-150d-11ea-87e7-751cb3dd1e64.png)
