### PR TITLE
Audio work

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -617,24 +617,28 @@ _passthrough_mode(){
 
 _audiopassthrough_mode(){
   if [[ "${MPV_INSTALL}" = 'Cellar' ]] ; then
-    PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=10: y=10:fontcolor=black"
+    PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135: y=380:fontcolor=black"
+    PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
+    PRINT_CHANNELS_3_4=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.3/4:x=10: y=10:fontcolor=white"
   fi
   if [[ "${AUDIO_MAPPING_CHOICE}" = '2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)' ]] ; then
     AUDIO_SPLIT='6[a][b][c][d][e][ao]'
-    CHANNEL_PARAMS='[b]pan=stereo|c0=c0|c1=c1,avectorscope[bb],[e]pan=stereo|c0=c2|c1=c3,avectorscope[ee]'
-    AP_MAP='[aa][bb][ee][x][dd]xstack=inputs=5:layout=0_0|h0_0|h0+h1_0|h0+h1+h2_0|0_h0[vo]'
+    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1],[e]pan=stereo|c0=c2|c1=c3,avectorscope${PRINT_CHANNELS_3_4}[e1]"
+    AP_MAP='[a1][b1][e1][x][d1]xstack=inputs=5:layout=0_0|h0_0|h0+h1_0|h0+h1+h2_0|0_h0[vo]'
+    SPECTRUM_SIZE='1200x300'
   else
     AUDIO_SPLIT='5[a][b][c][d][ao]'
-    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope[bb]"
-    AP_MAP='[aa][bb][x][dd]xstack=inputs=4:layout=0_0|h0_0|h0+h1_0|0_h0[vo]'
+    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1]"
+    AP_MAP='[a1][b1][x][d1]xstack=inputs=4:layout=0_0|h0_0|h0+h1_0|0_h0[vo]'
+    SPECTRUM_SIZE='900x300'
   fi
     PLAYBACKFILTER="[aid1]asplit=${AUDIO_SPLIT},\
-    [a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x400${PRINT_PHASE}[aa],\
+    [a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x400${PRINT_PHASE}[a1],\
     ${CHANNEL_PARAMS},\
-    [c]showvolume=t=0:h=17:w=200[cc],\
-    [d]showspectrum=s=900x300:fps=10:color=rainbow:legend=1[dd],\
+    [c]showvolume=t=0:h=17:w=200[c1],\
+    [d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:legend=1[d1],\
     [vid1]scale=400x400[vidscale],\
-    [vidscale][cc]overlay=10:10[x],\
+    [vidscale][c1]overlay=10:10[x],\
     ${AP_MAP}"
     echo "ESC quit" > ~/.config/mpv/input.conf
     _check_mpv

--- a/vrecord
+++ b/vrecord
@@ -35,6 +35,9 @@ MPVOPTS=(--no-osc)
 MPVOPTS+=(--load-scripts=no)
 MPVOPTS+=(--script "${RESOURCE_PATH}/qcview.lua")
 MPVOPTS+=(--really-quiet)
+if [[ -e "$(brew --prefix)/bin/mpv"  ]] ; then
+  MPV_INSTALL='Cellar'
+fi
 
 if [[ "$("${FFMPEG_DECKLINK}" -version 2>&1 | grep "Library not loaded" >/dev/null)" || ! -f "${FFMPEG_DECKLINK}" || ! -f "${FFPLAY_DECKLINK}" ]] ; then
     echo "Please reinstall 'ffmpegdecklink':"
@@ -613,15 +616,26 @@ _passthrough_mode(){
 }
 
 _audiopassthrough_mode(){
-    PLAYBACKFILTER="\
-[aid1]asplit=6[a][b][c][d][e][ao],\
-[a]showvolume=t=0:h=17:w=200[a1],\
-[b]pan=stereo|c0=c0|c1=c1,avectorscope[b1],\
-[c]pan=stereo|c0=c2|c1=c3,avectorscope[c1],\
-[d]showspectrum=s=535x672:color=rainbow:legend=1[d1],\
-[e]showwaves=split_channels=1:s=500x500:mode=cline[e1],\
-[vid1][b1][c1][e1][d1]xstack=inputs=5:layout=0_0|0_h0|0_h0+h1|w0_0|w1_h0[abcde1],\
-[abcde1][a1]overlay=10:10[vo]"
+  if [[ "${MPV_INSTALL}" = 'Cellar' ]] ; then
+    PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=10: y=10:fontcolor=black"
+  fi
+  if [[ "${AUDIO_MAPPING_CHOICE}" = '2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)' ]] ; then
+    AUDIO_SPLIT='6[a][b][c][d][e][ao]'
+    CHANNEL_PARAMS='[b]pan=stereo|c0=c0|c1=c1,avectorscope[bb],[e]pan=stereo|c0=c2|c1=c3,avectorscope[ee]'
+    AP_MAP='[aa][bb][ee][x][dd]xstack=inputs=5:layout=0_0|h0_0|h0+h1_0|h0+h1+h2_0|0_h0[vo]'
+  else
+    AUDIO_SPLIT='5[a][b][c][d][ao]'
+    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope[bb]"
+    AP_MAP='[aa][bb][x][dd]xstack=inputs=4:layout=0_0|h0_0|h0+h1_0|0_h0[vo]'
+  fi
+    PLAYBACKFILTER="[aid1]asplit=${AUDIO_SPLIT},\
+    [a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x400${PRINT_PHASE}[aa],\
+    ${CHANNEL_PARAMS},\
+    [c]showvolume=t=0:h=17:w=200[cc],\
+    [d]showspectrum=s=900x300:fps=10:color=rainbow:legend=1[dd],\
+    [vid1]scale=400x400[vidscale],\
+    [vidscale][cc]overlay=10:10[x],\
+    ${AP_MAP}"
     echo "ESC quit" > ~/.config/mpv/input.conf
     _check_mpv
     if [[ "${DEVICE_INPUT_CHOICE}" = "1" ]] ; then
@@ -630,7 +644,7 @@ _audiopassthrough_mode(){
         mpv - --title="${WINDOW_NAME}" -lavfi-complex "${PLAYBACKFILTER}"
     else
         "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> /tmp/vrecord_input.log | \
-        mpv - --title="${WINDOW_NAME}" -lavfi-complex "${PLAYBACKFILTER}"
+        mpv - --title="${WINDOW_NAME}" --cache=yes --cache-secs=60 -lavfi-complex "${PLAYBACKFILTER}"
     fi
     _gui_return
 }

--- a/vrecord
+++ b/vrecord
@@ -36,7 +36,7 @@ MPVOPTS+=(--load-scripts=no)
 MPVOPTS+=(--script "${RESOURCE_PATH}/qcview.lua")
 MPVOPTS+=(--really-quiet)
 if [[ -e "$(brew --prefix)/bin/mpv"  ]] ; then
-  MPV_INSTALL='Cellar'
+    MPV_INSTALL='Cellar'
 fi
 
 if [[ "$("${FFMPEG_DECKLINK}" -version 2>&1 | grep "Library not loaded" >/dev/null)" || ! -f "${FFMPEG_DECKLINK}" || ! -f "${FFPLAY_DECKLINK}" ]] ; then
@@ -616,24 +616,33 @@ _passthrough_mode(){
 }
 
 _audiopassthrough_mode(){
-  if [[ "${MPV_INSTALL}" = 'Cellar' ]] ; then
-    PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135: y=380:fontcolor=black"
-    PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
-    PRINT_CHANNELS_3_4=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.3/4:x=10: y=10:fontcolor=white"
-  fi
-  if [[ "${AUDIO_MAPPING_CHOICE}" = '2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)' ]] ; then
-    AUDIO_SPLIT='6[a][b][c][d][e][ao]'
-    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1],[e]pan=stereo|c0=c2|c1=c3,avectorscope${PRINT_CHANNELS_3_4}[e1]"
-    AP_MAP='[a1][b1][e1][x][d1]xstack=inputs=5:layout=0_0|h0_0|h0+h1_0|h0+h1+h2_0|0_h0[vo]'
-    SPECTRUM_SIZE='1200x300'
-  else
-    AUDIO_SPLIT='5[a][b][c][d][ao]'
-    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1]"
-    AP_MAP='[a1][b1][x][d1]xstack=inputs=4:layout=0_0|h0_0|h0+h1_0|0_h0[vo]'
-    SPECTRUM_SIZE='900x300'
-  fi
+    if [[ "${AUDIO_MAPPING_CHOICE}" = '2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)' ]] ; then
+        if [[ "${MPV_INSTALL}" = 'Cellar' ]] ; then
+            PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=1 80:fontcolor=black"
+            PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
+            PRINT_CHANNELS_3_4=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.3/4:x=10: y=10:fontcolor=white"
+        fi
+        AUDIO_SPLIT='7[a][aa][b][c][d][e][ao]'
+        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1],[e]pan=stereo|c0=c2|c1=c3,avectorscope${PRINT_CHANNELS_3_4}[e1]"
+        AP_MAP='[phase1][phase2][b1][e1][x][d1]xstack=inputs=6:layout=0_0|0_h0|w0_0|w0+w1_0|w0+w1+w2_0|0_h0+h1[vo]'
+        PHASE_LOCATION='x=135:y=180'
+        PHASE_MAP="[a]pan=stereo|c0=c0|c1=c1,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[phase1],\
+        [aa]pan=stereo|c0=c2|c1=c3,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_3_4}[phase2]"
+        SPECTRUM_SIZE='1315x300'
+    else
+        if [[ "${MPV_INSTALL}" = 'Cellar' ]] ; then
+            PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=380:fontcolor=black"
+            PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
+        fi
+        AUDIO_SPLIT='5[a][b][c][d][ao]'
+        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1]"
+        AP_MAP='[a1][b1][x][d1]xstack=inputs=4:layout=0_0|h0_0|h0+h1_0|0_h0[vo]'
+        PHASE_LOCATION='x=135:y=380'
+        PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
+        SPECTRUM_SIZE='915x300'
+    fi
     PLAYBACKFILTER="[aid1]asplit=${AUDIO_SPLIT},\
-    [a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x400${PRINT_PHASE}[a1],\
+    ${PHASE_MAP},\
     ${CHANNEL_PARAMS},\
     [c]showvolume=t=0:h=17:w=200[c1],\
     [d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:legend=1[d1],\
@@ -648,7 +657,7 @@ _audiopassthrough_mode(){
         mpv - --title="${WINDOW_NAME}" -lavfi-complex "${PLAYBACKFILTER}"
     else
         "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> /tmp/vrecord_input.log | \
-        mpv - --title="${WINDOW_NAME}" --cache=yes --cache-secs=60 -lavfi-complex "${PLAYBACKFILTER}"
+        mpv - --title="${WINDOW_NAME}" --cache=no -lavfi-complex "${PLAYBACKFILTER}"
     fi
     _gui_return
 }


### PR DESCRIPTION
Reworked the audio passthrough filters to include better monitoring of phase - example below for stereo input. (Added conditionals to build graph differently if two stereo channels are being used).

Video monitoring is a little squished now, but this seemed neater to me since video is just a reference in this mode.

Also added test for Cellar version of MPV due to lack of libfreetype support in Ubuntu PPA version.
 
![audio-passthrough](https://user-images.githubusercontent.com/12941699/72296117-c1ac7100-360d-11ea-96af-7814f757b3c0.png)
