### PR TITLE
Audio + Video

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -613,33 +613,37 @@ _passthrough_mode(){
 }
 
 _audiopassthrough_mode(){
+    VECTORSCOPE_FILTER="\
+format=yuv422p,\
+vectorscope=i=0.04:mode=color2:c=1:envelope=instant:graticule=green:flags=name,\
+scale=400:400"
     if [[ "${AUDIO_MAPPING_CHOICE}" = '2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)' ]] ; then
         PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=1 80:fontcolor=black"
         PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
         PRINT_CHANNELS_3_4=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.3/4:x=10: y=10:fontcolor=white"
         AUDIO_SPLIT='7[a][aa][b][c][d][e][out1]'
-        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1],[e]pan=stereo|c0=c2|c1=c3,avectorscope${PRINT_CHANNELS_3_4}[e1]"
-        AP_MAP='[phase1][phase2][b1][e1][x][d1]xstack=inputs=6:layout=0_0|0_h0|w0_0|w0+w1_0|w0+w1+w2_0|0_h0+h1,fps=25[out0]'
+        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=320x400${PRINT_CHANNELS_1_2}[b1],[e]pan=stereo|c0=c2|c1=c3,avectorscope=s=320x400${PRINT_CHANNELS_3_4}[e1]"
+        AP_MAP='[phase1][phase2][b1][e1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=9:layout=0_0|0_h0|w0_0|w0+w2_0|w0+w2+w3_0|0_h0+h1|0_h0+h1+h5|w6_h0+h1+h5|w5_h0+h1,fps=25[out0]'
         PHASE_LOCATION='x=135:y=180'
         PHASE_MAP="[a]pan=stereo|c0=c0|c1=c1,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[phase1],\
         [aa]pan=stereo|c0=c2|c1=c3,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_3_4}[phase2]"
-        SPECTRUM_SIZE='1315x300'
+        SPECTRUM_SIZE='755x265'
     else
         PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=380:fontcolor=black"
         PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
         AUDIO_SPLIT='5[a][b][c][d][out1]'
-        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=300x400${PRINT_CHANNELS_1_2}[b1]"
-        AP_MAP='[a1][b1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=7:layout=0_0|w0_0|w0+w1_0|0_h0|0_h0+h3|w4_h0+h3|w0+w1+w2_0,fps=25[out0]'
+        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=320x400${PRINT_CHANNELS_1_2}[b1]"
+        AP_MAP='[a1][b1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=7:layout=0_0|w0_0|w0+w1_0|0_h0+h4|0_h0|w4_h0|w0+w1+w2_0,fps=25[out0]'
         PHASE_LOCATION='x=135:y=380'
-        PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=300x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
-        SPECTRUM_SIZE='500x200'
+        PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=320x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
+        SPECTRUM_SIZE='1155x200'
     fi
     PLAYBACKFILTER="streams=dv+da[vid][aud],[aud]asplit=${AUDIO_SPLIT},\
     ${PHASE_MAP},\
     ${CHANNEL_PARAMS},\
     [c]showvolume=t=0:h=17:w=200[c1],\
     [d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:legend=1[d1],\
-    [vid]split=4[vid1][vid2][vid3][vid4],[vid1]scale=400x400[vidscale],\
+    [vid]split=4[vid1][vid2][vid3][vid4],[vid1]scale=400x400,signalstats=out=brng[vidscale],\
     [vid2]field=top,${WAVEFORM_FILTER}[TFIELD],\
     [vid3]field=bottom,${WAVEFORM_FILTER}[BFIELD],\
     [vid4]${VECTORSCOPE_FILTER}[vector],\

--- a/vrecord
+++ b/vrecord
@@ -642,7 +642,7 @@ scale=400:400"
     ${PHASE_MAP},\
     ${CHANNEL_PARAMS},\
     [c]showvolume=t=0:h=17:w=200[c1],\
-    [d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:legend=1[d1],\
+    [d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:saturation=2:legend=1[d1],\
     [vid]split=4[vid1][vid2][vid3][vid4],[vid1]scale=400x400,signalstats=out=brng[vidscale],\
     [vid2]field=top,${WAVEFORM_FILTER}[TFIELD],\
     [vid3]field=bottom,${WAVEFORM_FILTER}[BFIELD],\

--- a/vrecord
+++ b/vrecord
@@ -628,18 +628,21 @@ _audiopassthrough_mode(){
         PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=380:fontcolor=black"
         PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
         AUDIO_SPLIT='5[a][b][c][d][out1]'
-        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope${PRINT_CHANNELS_1_2}[b1]"
-        AP_MAP='[a1][b1][x][d1]xstack=inputs=4:layout=0_0|h0_0|h0+h1_0|0_h0,fps=25[out0]'
+        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=300x400${PRINT_CHANNELS_1_2}[b1]"
+        AP_MAP='[a1][b1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=7:layout=0_0|w0_0|w0+w1_0|0_h0|0_h0+h3|w4_h0+h3|w0+w1+w2_0,fps=25[out0]'
         PHASE_LOCATION='x=135:y=380'
-        PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
-        SPECTRUM_SIZE='915x300'
+        PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=300x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
+        SPECTRUM_SIZE='500x200'
     fi
     PLAYBACKFILTER="streams=dv+da[vid][aud],[aud]asplit=${AUDIO_SPLIT},\
     ${PHASE_MAP},\
     ${CHANNEL_PARAMS},\
     [c]showvolume=t=0:h=17:w=200[c1],\
     [d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:legend=1[d1],\
-    [vid]scale=400x400[vidscale],\
+    [vid]split=4[vid1][vid2][vid3][vid4],[vid1]scale=400x400[vidscale],\
+    [vid2]field=top,${WAVEFORM_FILTER}[TFIELD],\
+    [vid3]field=bottom,${WAVEFORM_FILTER}[BFIELD],\
+    [vid4]${VECTORSCOPE_FILTER}[vector],\
     [vidscale][c1]overlay=10:10[x],\
     ${AP_MAP}"
 

--- a/vrecord
+++ b/vrecord
@@ -233,7 +233,7 @@ _gtk_vbox_list() {
         if [[ "${VARIABLE_NAME}" == "VIDEO_CODEC_CHOICE" ]] ; then
             echo '<action condition="command_is_true( [ \"$VIDEO_CODEC_CHOICE\" = \"FFV1 version 3\" ] && echo true)">enable:FFV1_SLICE_CHOICE</action>
                   <action condition="command_is_true( [ \"$VIDEO_CODEC_CHOICE\" != \"FFV1 version 3\" ] && echo true)">disable:FFV1_SLICE_CHOICE</action>'
-        elif [[ "${VARIABLE_NAME}" == "CONTAINER_CHOICE" ]] ;then
+        elif [[ "${VARIABLE_NAME}" == "CONTAINER_CHOICE" ]] ; then
             echo '<action condition="command_is_true( [ \"$CONTAINER_CHOICE\" = \"Matroska\" ] && echo true)">enable:EMBED_LOGS_CHOICE</action>
                   <action condition="command_is_true( [ \"$CONTAINER_CHOICE\" != \"Matroska\" ] && echo true)">disable:EMBED_LOGS_CHOICE</action>'
         fi
@@ -347,7 +347,7 @@ AVFOUNDATION_INPUT_GUI="
             <frame Playback options>
                 <hbox space-expand=\"true\">
                     $(_gtk_vbox_list "PLAYBACKVIEW_CHOICE"      "Select View (for recording)"   "${PLAYBACKVIEW_OPTIONS[@]}")
-                    $(_gtk_vbox_list "PLAYBACKVIEW_CHOICE_PASS" "Select View (for passthrough)" "${PLAYBACKVIEW_OPTIONS[@]}")
+                    $(_gtk_vbox_list "PLAYBACKVIEW_CHOICE_PASS" "Select View (for passthrough)" "${PLAYBACKVIEW_PASS_OPTIONS[@]}")
                 </hbox>
             </frame>
             <frame Sidecar file options>
@@ -606,6 +606,15 @@ _passthrough_mode(){
         "${FFMPEG_DECKLINK}" -nostats "${GRAB_INPUT[@]}" 2> >(tee /tmp/vrecord_input.log 1>&2) \
         "${PIPE_OUTPUT[@]}" | \
         mpv "${MPVOPTS[@]}" --title="${WINDOW_NAME}" -
+    elif [[ "${PLAYBACKVIEW_CHOICE_PASS}" = "Audio + Video" ]] ; then
+        if [[ "${DEVICE_INPUT_CHOICE}" = "1" ]] ; then
+            unset PIPE_OUTPUT[0] && unset PIPE_OUTPUT[1]
+            "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}" -c copy -f rawvideo - | "${FFMPEG_DECKLINK}" -i - "${PIPE_OUTPUT[@]}" 2> /tmp/vrecord_input.log | \
+            "${FFPLAY_DECKLINK}" -window_title "${WINDOW_NAME}" -f lavfi "movie='pipe\:0':${PLAYBACKFILTER}"
+        else
+            "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> /tmp/vrecord_input.log | \
+            "${FFPLAY_DECKLINK}" -window_title "${WINDOW_NAME}" -f lavfi "movie='pipe\:0':${PLAYBACKFILTER}"
+        fi
     else
         "${FFPLAY_DECKLINK}" "${FFPLAY_OPTIONS[@]}" 2> >(tee /tmp/vrecord_input.log 1>&2)
     fi
@@ -613,52 +622,9 @@ _passthrough_mode(){
 }
 
 _audiopassthrough_mode(){
-    VECTORSCOPE_FILTER="\
-format=yuv422p,\
-vectorscope=i=0.04:mode=color2:c=1:envelope=instant:graticule=green:flags=name,\
-scale=400:400"
-    if [[ "${AUDIO_MAPPING_CHOICE}" = '2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)' ]] ; then
-        PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=1 80:fontcolor=black"
-        PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
-        PRINT_CHANNELS_3_4=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.3/4:x=10: y=10:fontcolor=white"
-        AUDIO_SPLIT='7[a][aa][b][c][d][e][out1]'
-        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=320x400${PRINT_CHANNELS_1_2}[b1],[e]pan=stereo|c0=c2|c1=c3,avectorscope=s=320x400${PRINT_CHANNELS_3_4}[e1]"
-        AP_MAP='[phase1][phase2][b1][e1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=9:layout=0_0|0_h0|w0_0|w0+w2_0|w0+w2+w3_0|0_h0+h1|0_h0+h1+h5|w6_h0+h1+h5|w5_h0+h1,fps=25[out0]'
-        PHASE_LOCATION='x=135:y=180'
-        PHASE_MAP="[a]pan=stereo|c0=c0|c1=c1,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[phase1],\
-        [aa]pan=stereo|c0=c2|c1=c3,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_3_4}[phase2]"
-        SPECTRUM_SIZE='755x265'
-    else
-        PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=380:fontcolor=black"
-        PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
-        AUDIO_SPLIT='5[a][b][c][d][out1]'
-        CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=320x400${PRINT_CHANNELS_1_2}[b1]"
-        AP_MAP='[a1][b1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=7:layout=0_0|w0_0|w0+w1_0|0_h0+h4|0_h0|w4_h0|w0+w1+w2_0,fps=25[out0]'
-        PHASE_LOCATION='x=135:y=380'
-        PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=320x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
-        SPECTRUM_SIZE='1155x200'
-    fi
-    PLAYBACKFILTER="streams=dv+da[vid][aud],[aud]asplit=${AUDIO_SPLIT},\
-    ${PHASE_MAP},\
-    ${CHANNEL_PARAMS},\
-    [c]showvolume=t=0:h=17:w=200[c1],\
-    [d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:saturation=2:legend=1[d1],\
-    [vid]split=4[vid1][vid2][vid3][vid4],[vid1]scale=400x400,signalstats=out=brng[vidscale],\
-    [vid2]field=top,${WAVEFORM_FILTER}[TFIELD],\
-    [vid3]field=bottom,${WAVEFORM_FILTER}[BFIELD],\
-    [vid4]${VECTORSCOPE_FILTER}[vector],\
-    [vidscale][c1]overlay=10:10[x],\
-    ${AP_MAP}"
-
-    if [[ "${DEVICE_INPUT_CHOICE}" = "1" ]] ; then
-        unset PIPE_OUTPUT[0] && unset PIPE_OUTPUT[1]
-        "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}" -c copy -f rawvideo - | "${FFMPEG_DECKLINK}" -i - "${PIPE_OUTPUT[@]}" 2> /tmp/vrecord_input.log | \
-        "${FFPLAY_DECKLINK}" -window_title "${WINDOW_NAME}" -f lavfi "movie='pipe\:0':${PLAYBACKFILTER}"
-    else
-        "${FFMPEG_DECKLINK}" -nostdin -hide_banner -nostats "${INPUTOPTIONS[@]}" "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> /tmp/vrecord_input.log | \
-        "${FFPLAY_DECKLINK}" -window_title "${WINDOW_NAME}" -f lavfi "movie='pipe\:0':${PLAYBACKFILTER}"
-    fi
-    _gui_return
+    PLAYBACKVIEW_CHOICE_PASS="Audio + Video"
+    _lookup_choice "Audio + Video"
+    _passthrough_mode
 }
 
 # check validity of duration value
@@ -923,6 +889,43 @@ _lookup_choice(){
         # playback views
         "Unfiltered") PLAYBACKFILTER="" ;;
         "Quality Control View (mpv)") MEDIA_PLAYER_CHOICE="mpv" ;;
+        "Audio + Video")
+            VECTORSCOPE_FILTER="\
+format=yuv422p,\
+vectorscope=i=0.04:mode=color2:c=1:envelope=instant:graticule=green:flags=name,\
+scale=400:400"
+if [[ "${AUDIO_MAPPING_CHOICE}" = '2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)' ]] ; then
+    PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=1 80:fontcolor=black"
+    PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
+    PRINT_CHANNELS_3_4=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.3/4:x=10: y=10:fontcolor=white"
+    AUDIO_SPLIT='7[a][aa][b][c][d][e][out1]'
+    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=320x400${PRINT_CHANNELS_1_2}[b1],[e]pan=stereo|c0=c2|c1=c3,avectorscope=s=320x400${PRINT_CHANNELS_3_4}[e1]"
+    AP_MAP='[phase1][phase2][b1][e1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=9:layout=0_0|0_h0|w0_0|w0+w2_0|w0+w2+w3_0|0_h0+h1|0_h0+h1+h5|w6_h0+h1+h5|w5_h0+h1,fps=25[out0]'
+    PHASE_LOCATION='x=135:y=180'
+    PHASE_MAP="[a]pan=stereo|c0=c0|c1=c1,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[phase1],\
+    [aa]pan=stereo|c0=c2|c1=c3,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_3_4}[phase2]"
+    SPECTRUM_SIZE='755x265'
+else
+    PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1: text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=380:fontcolor=black"
+    PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}: text=Ch.1/2:x=10: y=10:fontcolor=white"
+    AUDIO_SPLIT='5[a][b][c][d][out1]'
+    CHANNEL_PARAMS="[b]pan=stereo|c0=c0|c1=c1,avectorscope=s=320x400${PRINT_CHANNELS_1_2}[b1]"
+    AP_MAP='[a1][b1][x][d1][TFIELD][BFIELD][vector]xstack=inputs=7:layout=0_0|w0_0|w0+w1_0|0_h0+h4|0_h0|w4_h0|w0+w1+w2_0,fps=25[out0]'
+    PHASE_LOCATION='x=135:y=380'
+    PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=320x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
+    SPECTRUM_SIZE='1155x200'
+fi
+PLAYBACKFILTER="streams=dv+da[vid][aud],[aud]asplit=${AUDIO_SPLIT},\
+${PHASE_MAP},\
+${CHANNEL_PARAMS},\
+[c]showvolume=t=0:h=17:w=200[c1],\
+[d]showspectrum=s=${SPECTRUM_SIZE}:fps=10:color=rainbow:saturation=2:legend=1[d1],\
+[vid]split=4[vid1][vid2][vid3][vid4],[vid1]scale=400x400,signalstats=out=brng[vidscale],\
+[vid2]field=top,${WAVEFORM_FILTER}[TFIELD],\
+[vid3]field=bottom,${WAVEFORM_FILTER}[BFIELD],\
+[vid4]${VECTORSCOPE_FILTER}[vector],\
+[vidscale][c1]overlay=10:10[x],\
+${AP_MAP}" ;;
         "Broadcast Range Visual")
             PLAYBACKFILTER="\
 ${PLAYBACK_FILTER_ADJUSTMENT}split=5[a][b][c][d][e];\
@@ -1137,6 +1140,8 @@ FRAMEMD5_OPTIONS=("Yes" "No")
 EMBED_LOGS_OPTIONS=("Yes" "No")
 DURATION_OPTIONS=(23 33 63 93)
 PLAYBACKVIEW_OPTIONS=("Unfiltered" "Quality Control View (mpv)" "Broadcast Range Visual" "Full Range Visual" "Visual + Numerical" "Color Matrix" "Bit Planes")
+PLAYBACKVIEW_PASS_OPTIONS=("Unfiltered" "Quality Control View (mpv)" "Broadcast Range Visual" "Audio + Video" "Full Range Visual" "Visual + Numerical" "Color Matrix" "Bit Planes")
+
 
 # GUI mode + CLI reset, edit modes
 if [[ "${RUNTYPE}" = "GUI" ]] ; then


### PR DESCRIPTION
* Update audio monitoring filters to 'Audio + Video' (aka Ben Turkus mode)
* Add 'Audio + Video' to GUI list of passthrough mode views
* Combine audiopassthrough with passthrough functions, while still allowing audiopassthrough to be called with `-a` if desired (this allows audiopassthrough to still be easily called even if different passthrough mode has been set in GUI)