### PR TITLE
Fix audio regression in ffv1

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1152,6 +1152,7 @@ if [[ "${INVERT_PHASE}" = 'true' ]] ; then
 fi
 
 _review_option(){
+    unset NO_LOOKUP
     OPTIND=1
     while getopts "n" opt ; do
         case "${opt}" in


### PR DESCRIPTION
In FFV1, variable that blocks lookup function persists. This causes audio codec to not be looked up, and vrecord switches to matroska default (vorbis).

This unsets variable and fixes issue reported in https://github.com/amiaopensource/vrecord/issues/497