### PR TITLE
[WIP] add Hi59 format

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -921,6 +921,16 @@ _lookup_choice(){
             MIDDLEOPTIONS+=(-color_primaries bt470bg)
             MIDDLEOPTIONS+=(-color_trc bt709)
             MIDDLEOPTIONS+=(-colorspace bt470bg) ;;
+        "Hi59")
+            STANDARD="Hi59"
+            DECKLINK_FPS="30000/1001"
+            if [[ "${VIDEO_CODEC_CHOICE}" = "h264" ]] ; then
+                MIDDLEOPTIONS+=(-x264opts tff)
+            fi
+            RECORDINGFILTER="setdar=16/9"
+            MIDDLEOPTIONS+=(-color_primaries bt709)
+            MIDDLEOPTIONS+=(-color_trc bt709)
+            MIDDLEOPTIONS+=(-colorspace bt709) ;;
 
         # playback views
         "Unfiltered") PLAYBACKFILTER="" ;;
@@ -1170,7 +1180,7 @@ AUDIO_CODEC_OPTIONS=("24-bit PCM" "24-bit FLAC" "AAC")
 VIDEO_BITDEPTH_OPTIONS=("10 bit" "8 bit")
 CHANNEL_MAPPING_OPTIONS=("2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)" "1 Stereo Track (From Channels 1 & 2)" "1 Stereo Track (From Channels 3 & 4)" "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono" "Channel 2 -> 1st Track Mono, Channel 1 -> 2nd Track Mono" "Channel 1 -> Single Track Mono" "Channel 2 -> Single Track Mono")
 TIMECODE_OPTIONS=("none" "rp188vitc" "rp188vitc2" "rp188ltc" "rp188any" "vitc" "vitc2" "serial")
-STANDARD_OPTIONS=("NTSC" "PAL")
+STANDARD_OPTIONS=("NTSC" "PAL" "Hi59")
 QCTOOLSXML_OPTIONS=("Yes, after recording" "Yes, concurrent with recording" "No")
 FRAMEMD5_OPTIONS=("Yes" "No")
 EMBED_LOGS_OPTIONS=("Yes" "No")


### PR DESCRIPTION
This PR starts to add HD formats to vrecord via decklink, starting with Hi59. 

I'm testing this with an UltraStudio Express and a mac like this:
```
computer_model_id: iMacPro1,1
computer_processor_name: Intel Xeon W
computer_processor_speed: 2.3 GHz
computer_processor_count: 1
computer_memory: 128 GB
computer_cores: 18
```

For tests I'm using the unfiltered view, no qctools (or qctools after capture). The capture lags within a few minutes when recording 10 bit ffv1, but seems ok with 8 bit ffv1. So far I've only tested up to 20 minutes though. I think documentation would be needed to describe what's reasonable when trying to force HD through this process. The HD source I tested with had nulled 9/10 bits so it was fine, but soon I'll test with HDCam source.


