### PR TITLE
fix an issue with validation an option to the wrong vocabulary

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1896,7 +1896,7 @@ if [[ "${CORE_COUNT}" -le 2 && "${RUNTYPE}" = "record" ]] ; then
     PLAYBACK_FILTER_ADJUSTMENT="select=not(mod(n\,2)),"
 fi
 if [[ "${RUNTYPE}" = "passthrough" ]] && [[ -n "${PLAYBACKVIEW_CHOICE_PASS}" ]] && [[ "${PLAYBACKVIEW_CHOICE_PASS}" != "Unselected" ]] ; then
-  _review_option "PLAYBACKVIEW_CHOICE_PASS" "${PLAYBACKVIEW_OPTIONS[@]}"
+  _review_option "PLAYBACKVIEW_CHOICE_PASS" "${PLAYBACKVIEW_PASS_OPTIONS[@]}"
 else
   _review_option "PLAYBACKVIEW_CHOICE" "${PLAYBACKVIEW_OPTIONS[@]}"
 fi


### PR DESCRIPTION
This would cause an error was passthrough mode was set to "Audio + Video"