### PR TITLE
Bmdtools is back

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -2300,6 +2300,7 @@ _report -d "Close the playback window to stop recording."
 if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     # DEVICE_INPUT_CHOICE=0 is decklink, other DEVICE_INPUT_CHOICE values don't yet use such filtering
     if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+        VRECORD_STEPS="3"
         RECORD_COMMAND=(bmdcapture)
         # TO DO adjust TIME_LIMIT for bmdcapture
         RECORD_COMMAND+=("${GRAB_INPUT[@]}")
@@ -2314,6 +2315,7 @@ if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
         FF_RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
     else
         #TO DO indent
+    VRECORD_STEPS="2"
     RECORD_COMMAND=("${FFMPEG_BIN}")
     RECORD_COMMAND+=(-nostdin -nostats "${TIME_LIMIT[@]}" "${GRAB_INPUT[@]}")
     if [[ -n "${VIDEOCODECNAME}" ]] ; then
@@ -2331,6 +2333,7 @@ if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
         PLAYER_COMMAND=("${FFPLAY_BIN}" "${FFPLAY_OPTIONS[@]}")
     fi
 elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
+    VRECORD_STEPS="3"
     RECORD_COMMAND=(avfctl)
     RECORD_COMMAND+=("${GRAB_INPUT[@]}")
     FF_RECORD_COMMAND=("${FFMPEG_BIN}" -nostdin -nostats "${TIME_LIMIT[@]}")
@@ -2338,38 +2341,37 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     FF_RECORD_COMMAND+=(-map 0:v -c copy)
     FF_RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
     FF_RECORD_COMMAND+=(-map 0:v -f rawvideo -c copy -)
+    PLAYER_COMMAND=("${FFPLAY_BIN}" -)
 elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
+    VRECORD_STEPS="2"
     RECORD_COMMAND=("${FFMPEG_BIN}")
     RECORD_COMMAND+=(-nostdin -nostats "${TIME_LIMIT[@]}" "${GRAB_INPUT[@]}")
     RECORD_COMMAND+=("${MIDDLEOPTIONS[@]}")
     RECORD_COMMAND+=(-f "${FORMAT}" -filter_complex "${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" "${VRECORD_OUTPUT}")
     RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" -filter_complex "${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" "${PIPE_OUTPUT[@]}")
+    PLAYER_COMMAND=("${FFPLAY_BIN}" -f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}")
 else
     _report_unexpected_error DEVICE_INPUT_CHOICE
 fi
 _writeingestlog "Recording command" "${RECORD_COMMAND[@]}"
 _set_ffplay_options
-if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
-        "${RECORD_COMMAND[@]}" \
-            2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) \
-            | \
-            if [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]] ; then
-                tee >("${PLAYER_COMMAND}") | \
-                    qcli -f signalstats+aphasemeter+astats+ssim -i - -o "${QCXML}"
-            else
-                "${PLAYER_COMMAND}"
-            fi
-elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
-    "${RECORD_COMMAND[@]}" \
-        2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
-        "${FF_RECORD_COMMAND[@]}" \
-        2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
-        "${FFPLAY_BIN}" -
-elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
-    "${RECORD_COMMAND[@]}" \
-        2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) \
-        | \
-        "${FFPLAY_BIN}" -f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}"
+if [[ "${VRECORD_STEPS}" = "2" ]] ; then
+    "${RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
+    if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] && [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]]; then
+        tee >("${PLAYER_COMMAND[@]}") | qcli -f signalstats+aphasemeter+astats+ssim -i - -o "${QCXML}"
+    else
+        "${PLAYER_COMMAND[@]}"
+    fi
+elif [[ "${VRECORD_STEPS}" = "3" ]] ; then
+    "${RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
+    "${FF_RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
+    if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] && [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]]; then
+        tee >("${PLAYER_COMMAND[@]}") | qcli -f signalstats+aphasemeter+astats+ssim -i - -o "${QCXML}"
+    else
+        "${PLAYER_COMMAND[@]}"
+    fi
+else
+    _report_unexpected_error VRECORD_STEPS
 fi
 # capture errors from components of recording pipe
 P1_ERR="${PIPESTATUS[0]}"

--- a/vrecord
+++ b/vrecord
@@ -238,7 +238,7 @@ MPVOPTS+=(--script="${RESOURCE_PATH}/qcview.lua")
 MPVOPTS+=(--really-quiet)
 
 _gather_ffmpeg_vars(){
-    CAPTURELOGSUFFIX="_ffmpeg_input.log"
+    CAPTURELOGSUFFIX="_vrecord_input.log"
     TIMECODELOGSUFFIX="_frame_timecodes.txt"
     if [[ -d "/usr/local/opt/ffmpegdecklink" ]] ; then
         BREW_PREFIX="/usr/local/opt/ffmpegdecklink"

--- a/vrecord
+++ b/vrecord
@@ -2366,7 +2366,7 @@ if [[ "${VRECORD_STEPS}" = "2" ]] ; then
     fi
 elif [[ "${VRECORD_STEPS}" = "3" ]] ; then
     _writeingestlog "Capture command" "${RECORD_COMMAND[@]}"
-    _writeingestlog "Record command" "${FF_ RECORD_COMMAND[@]}"
+    _writeingestlog "Record command" "${FF_RECORD_COMMAND[@]}"
     _writeingestlog "Playback command" "${PLAYER_COMMAND[@]}"
     "${RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
     "${FF_RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \

--- a/vrecord
+++ b/vrecord
@@ -2342,7 +2342,7 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     FF_RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
     FF_RECORD_COMMAND+=(-map 0:v -f rawvideo -c copy -)
     _set_ffplay_options
-    PLAYER_COMMAND=("${FFPLAY_BIN}" -)
+    PLAYER_COMMAND=("${FFPLAY_BIN}" "${FFPLAY_OPTIONS[@]}")
 elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
     VRECORD_STEPS="2"
     RECORD_COMMAND=("${FFMPEG_BIN}")

--- a/vrecord
+++ b/vrecord
@@ -2021,7 +2021,7 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
         GRAB_INPUT+=(-s 32)
         GRAB_INPUT+=(-p "${BMD_PIXEL_FORMAT}")
         GRAB_INPUT+=(-F "matroska")
-        GRAB_INPUT+=(-d "1")
+        GRAB_INPUT+=(-d "0")
         GRAB_INPUT+=(-f pipe:1)
     else
     ## TO INDENT

--- a/vrecord
+++ b/vrecord
@@ -89,6 +89,19 @@ _report(){
     MESSAGE="${1}"
     echo ${ECHOOPT} "${COLOR}${STARTMESSAGE[@]}${MESSAGE}${NC}"
 }
+_report_unexpected_error(){
+    ERROR_VAR_NAME="${1}"
+    ERROR_VAR_VALUE="${!1}"
+    ERROR_DETAIL="$2"
+    _report -d -wt "vrecord exited a form in an unexpected way (${ERROR_VAR_NAME}=${ERROR_VAR_VALUE}), please report this error to https://github.com/amiaopensource/vrecord/issues"
+    if [[ -n "${ERROR_DETAIL}" ]] ;then
+        _report -d -wt "Error details: ${ERROR_DETAIL}"
+    fi
+    if [[ -f "${INGESTLOG}" ]] ; then
+        _writeingestlog "vrecord command Error" "invalid ${ERROR_VAR_NAME} value of ${ERROR_VAR_VALUE}"
+    fi
+    exit 1
+}
 
 # command-line options to set media id and original variables
 OPTIND=1
@@ -1249,8 +1262,7 @@ _edit_mode(){
         done
         RUNTYPE="edit"
     else
-        _report -d -wt "vrecord exited a form in an unexpected way, please report this error to https://github.com/amiaopensource/vrecord/issues"
-        exit 1
+        _report_unexpected_error EXIT
     fi
 }
 
@@ -1290,8 +1302,7 @@ _passthrough_mode(){
         "${FFMPEG_BIN}" -nostdin -hide_banner -nostats "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> "${VRECORD_INPUT_TMP}" | \
             "${FFPLAY_BIN}" -window_title "${WINDOW_NAME}" -f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}"
     else
-        _report -d -wt "vrecord exited a form in an unexpected way, please report this error to https://github.com/amiaopensource/vrecord/issues"
-        exit 1
+        _report_unexpected_error DEVICE_INPUT_CHOICE
     fi
 }
 
@@ -2335,8 +2346,7 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
     RECORD_COMMAND+=(-f "${FORMAT}" -filter_complex "${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" "${VRECORD_OUTPUT}")
     RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" -filter_complex "${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" "${PIPE_OUTPUT[@]}")
 else
-    _report -d -wt "vrecord exited a form in an unexpected way (DEVICE_INPUT_CHOICE=${DEVICE_INPUT_CHOICE}), please report this error to https://github.com/amiaopensource/vrecord/issues"
-    exit 1
+    _report_unexpected_error DEVICE_INPUT_CHOICE
 fi
 _writeingestlog "Recording command" "${RECORD_COMMAND[@]}"
 _set_ffplay_options
@@ -2369,20 +2379,13 @@ P3_ERR="${PIPESTATUS[2]}"
 
 if [[ ! -s "${VRECORD_OUTPUT}" ]] ; then
     if [[ "$P1_ERR" != "0" ]] ; then
-        _report -wts "Error: Running: ${RECORD_COMMAND[@]} gave an Error Code - ${P1_ERR}"
-        _report -w "Consider reporting this or asking for help at https://github.com/amiaopensource/vrecord/issues"
-        _writeingestlog "vrecord command Error" "${P1_ERR}"
-        exit 1
+        _report_unexpected_error P1_ERR "${RECORD_COMMAND[@]} // ${FF_RECORD_COMMAND[@]} // ${PLAYER_COMMAND}"
     fi
     if [[ "$P2_ERR" != "0" && ! -z "$P2_ERR" ]] ; then
-        _report -wts "Error: The second component of vrecord recording process gave an Error Code - ${P2_ERR}"
-        _report -w "Consider reporting this or asking for help at https://github.com/amiaopensource/vrecord/issues"
-        _writeingestlog "vrecord command Error (P2)" "${P2_ERR}"
+        _report_unexpected_error P2_ERR "${RECORD_COMMAND[@]} // ${FF_RECORD_COMMAND[@]} // ${PLAYER_COMMAND}"
     fi
     if [[ "$P3_ERR" != "0" && ! -z "$P3_ERR" ]] ; then
-        _report -wts "Error: The third component of vrecord recording process gave an Error Code - ${P3_ERR}"
-        _report -w "Consider reporting this or asking for help at https://github.com/amiaopensource/vrecord/issues"
-        _writeingestlog "vrecord command Error (P3)" "${P3_ERR}"
+        _report_unexpected_error P3_ERR "${RECORD_COMMAND[@]} // ${FF_RECORD_COMMAND[@]} // ${PLAYER_COMMAND}"
     fi
 fi
 

--- a/vrecord
+++ b/vrecord
@@ -1590,14 +1590,14 @@ _lookup_choice(){
             STANDARD="ntsc"
             if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
                 BMD_STANDARD="$(bmdcapture -h 2>&1 | grep "NTSC.*29.97" | cut -d: -f 1 | sed 's/ //g' | head -n 1)"
+                RECORDINGFILTER+="setfield=bff,"
             fi
             DECKLINK_FPS="30000/1001"
             if [[ "${VIDEO_CODEC_CHOICE}" = "h264" ]] ; then
-                RECORDINGFILTER="crop=w=720:h=480:x=0:y=4,setsar=40/27,setdar=4/3"
+                RECORDINGFILTER+="crop=w=720:h=480:x=0:y=4,"
                 MIDDLEOPTIONS+=(-x264opts bff)
-            else
-                RECORDINGFILTER="setsar=40/27,setdar=4/3"
             fi
+            RECORDINGFILTER+="setsar=40/27,setdar=4/3"
             MIDDLEOPTIONS+=(-color_primaries smpte170m)
             MIDDLEOPTIONS+=(-color_trc bt709)
             MIDDLEOPTIONS+=(-colorspace smpte170m) ;;
@@ -1605,14 +1605,13 @@ _lookup_choice(){
             STANDARD="pal "
             if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
                 BMD_STANDARD="$(bmdcapture -h 2>&1 | grep "PAL.*25" | cut -d: -f 1 | sed 's/ //g' | head -n 1)"
+                RECORDINGFILTER+="setfield=tff,"
             fi
             DECKLINK_FPS="25000/1000"
             if [[ "${VIDEO_CODEC_CHOICE}" = "h264" ]] ; then
-                RECORDINGFILTER="setsar=16/15,setdar=4/3"
                 MIDDLEOPTIONS+=(-x264opts tff)
-            else
-                RECORDINGFILTER="setsar=16/15,setdar=4/3"
             fi
+            RECORDINGFILTER+="setsar=16/15,setdar=4/3"
             MIDDLEOPTIONS+=(-color_primaries bt470bg)
             MIDDLEOPTIONS+=(-color_trc bt709)
             MIDDLEOPTIONS+=(-colorspace bt470bg) ;;

--- a/vrecord
+++ b/vrecord
@@ -558,6 +558,8 @@ _set_up_edit_form() {
     for i in "${LIST[@]}" ; do
       if [[ "$i" == "Quality Control View (mpv)" ]] && ! $MPV_INSTALLED ; then
           :
+      elif [[ "$i" == "bmdcapture" ]] && ! $BMDTOOLS_INSTALLED ; then
+          :
       else
         echo "<item>${i}</item>"
       fi

--- a/vrecord
+++ b/vrecord
@@ -492,7 +492,6 @@ _gtk_vbox_list() {
 
     echo "<vbox>
       <text>
-          <width>${WIDTH}</width>
           <label>${LABEL}</label>
       </text>
       <list selection-mode=\"1\" selected-row=\"${SELECTION}\">

--- a/vrecord
+++ b/vrecord
@@ -2356,7 +2356,7 @@ else
     _report_unexpected_error DEVICE_INPUT_CHOICE
 fi
 if [[ "${VRECORD_STEPS}" = "2" ]] ; then
-    _writeingestlog "Capture-Record command" "${FF_RECORD_COMMAND[@]}"
+    _writeingestlog "Capture-Record command" "${RECORD_COMMAND[@]}"
     _writeingestlog "Playback command" "${PLAYER_COMMAND[@]}"
     "${RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
     if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] && [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]]; then

--- a/vrecord
+++ b/vrecord
@@ -2314,17 +2314,16 @@ if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
         FF_RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
         FF_RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
     else
-        #TO DO indent
-    VRECORD_STEPS="2"
-    RECORD_COMMAND=("${FFMPEG_BIN}")
-    RECORD_COMMAND+=(-nostdin -nostats "${TIME_LIMIT[@]}" "${GRAB_INPUT[@]}")
-    if [[ -n "${VIDEOCODECNAME}" ]] ; then
-        MIDDLEOPTIONS+=(-metadata:s:v:0 encoder="${VIDEOCODECNAME}")
-    fi
-    RECORD_COMMAND+=("${MIDDLEOPTIONS[@]}")
-    RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
-    RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
-    RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
+        VRECORD_STEPS="2"
+        RECORD_COMMAND=("${FFMPEG_BIN}")
+        RECORD_COMMAND+=(-nostdin -nostats "${TIME_LIMIT[@]}" "${GRAB_INPUT[@]}")
+        if [[ -n "${VIDEOCODECNAME}" ]] ; then
+            MIDDLEOPTIONS+=(-metadata:s:v:0 encoder="${VIDEOCODECNAME}")
+        fi
+        RECORD_COMMAND+=("${MIDDLEOPTIONS[@]}")
+        RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
+        RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
+        RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
     fi
     if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then
         _check_mpv

--- a/vrecord
+++ b/vrecord
@@ -2353,9 +2353,10 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
 else
     _report_unexpected_error DEVICE_INPUT_CHOICE
 fi
-_writeingestlog "Recording command" "${RECORD_COMMAND[@]}"
 _set_ffplay_options
 if [[ "${VRECORD_STEPS}" = "2" ]] ; then
+    _writeingestlog "Capture-Record command" "${FF_RECORD_COMMAND[@]}"
+    _writeingestlog "Playback command" "${PLAYER_COMMAND[@]}"
     "${RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
     if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] && [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]]; then
         tee >("${PLAYER_COMMAND[@]}") | qcli -f signalstats+aphasemeter+astats+ssim -i - -o "${QCXML}"
@@ -2363,6 +2364,9 @@ if [[ "${VRECORD_STEPS}" = "2" ]] ; then
         "${PLAYER_COMMAND[@]}"
     fi
 elif [[ "${VRECORD_STEPS}" = "3" ]] ; then
+    _writeingestlog "Capture command" "${RECORD_COMMAND[@]}"
+    _writeingestlog "Record command" "${FF_ RECORD_COMMAND[@]}"
+    _writeingestlog "Playback command" "${PLAYER_COMMAND[@]}"
     "${RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
     "${FF_RECORD_COMMAND[@]}" 2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
     if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] && [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]]; then
@@ -2374,9 +2378,19 @@ else
     _report_unexpected_error VRECORD_STEPS
 fi
 # capture errors from components of recording pipe
-P1_ERR="${PIPESTATUS[0]}"
-P2_ERR="${PIPESTATUS[1]}"
-P3_ERR="${PIPESTATUS[2]}"
+RESULTING_EXIT_CODES=("${PIPESTATUS[@]}")
+P1_ERR="${RESULTING_EXIT_CODES[0]}"
+P2_ERR="${RESULTING_EXIT_CODES[1]}"
+P3_ERR="${RESULTING_EXIT_CODES[2]}"
+
+if [[ "${VRECORD_STEPS}" = "2" ]] ; then
+    _writeingestlog "Capture-Record exit code" "${P1_ERR}"
+    _writeingestlog "Playback exit code" "${P2_ERR}"
+elif [[ "${VRECORD_STEPS}" = "3" ]] ; then
+    _writeingestlog "Capture exit code" "${P1_ERR}"
+    _writeingestlog "Record exit code" "${P2_ERR}"
+    _writeingestlog "Playback exit code" "${P3_ERR}"
+fi
 
 if [[ ! -s "${VRECORD_OUTPUT}" ]] ; then
     if [[ "$P1_ERR" != "0" ]] ; then

--- a/vrecord
+++ b/vrecord
@@ -2314,6 +2314,12 @@ if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
     RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
     fi
+    if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then
+        _check_mpv
+        PLAYER_COMMAND=(mpv "${MPVOPTS[@]}" --title="${WINDOW_NAME}" -)
+    else
+        PLAYER_COMMAND=("${FFPLAY_BIN}" "${FFPLAY_OPTIONS[@]}")
+    fi
 elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     RECORD_COMMAND=(avfctl)
     RECORD_COMMAND+=("${GRAB_INPUT[@]}")
@@ -2335,30 +2341,15 @@ fi
 _writeingestlog "Recording command" "${RECORD_COMMAND[@]}"
 _set_ffplay_options
 if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
-    if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then
-        _check_mpv
         "${RECORD_COMMAND[@]}" \
             2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) \
             | \
             if [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]] ; then
-                tee >(mpv "${MPVOPTS[@]}" --title="${WINDOW_NAME}" -) | \
+                tee >("${PLAYER_COMMAND}") | \
                     qcli -f signalstats+aphasemeter+astats+ssim -i - -o "${QCXML}"
             else
-                mpv "${MPVOPTS[@]}" --title="${WINDOW_NAME}" -
+                "${PLAYER_COMMAND}"
             fi
-    else
-        "${RECORD_COMMAND[@]}" \
-            2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) \
-            | \
-            if [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]] ; then
-                tee >("${FFPLAY_BIN}" "${FFPLAY_OPTIONS[@]}") | \
-                    qcli -f signalstats+aphasemeter+astats+ssim -i - -o "${QCXML}"
-            elif [[ "${DEVICE_INPUT_CHOICE}" = "2" ]] ; then
-                "${FFPLAY_BIN}" -window_title "${WINDOW_NAME}" -f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}"
-            else
-                "${FFPLAY_BIN}" "${FFPLAY_OPTIONS[@]}"
-            fi
-    fi
 elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     "${RECORD_COMMAND[@]}" \
         2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \

--- a/vrecord
+++ b/vrecord
@@ -336,6 +336,7 @@ _update_config_file(){
         echo "TECHNICIAN=\"${TECHNICIAN}\""
         echo "AVFCTL_INPUT_CHOICE=\"${AVFCTL_INPUT_CHOICE}\""
         echo "DECKLINK_INPUT_CHOICE=\"${DECKLINK_INPUT_CHOICE}\""
+        echo "DECKLINK_UTILITY_CHOICE=\"${DECKLINK_UTILITY_CHOICE}\""
     } > "${CONFIG_FILE}"
     . "${CONFIG_FILE}"
 }
@@ -404,7 +405,11 @@ _get_output_filename(){
 _get_decklink_inputs(){
     # get information on what input device options are available
     #unset DECKLINK_DEVICES
-    "${FFMPEG_BIN}" -nostdin -v 0 -sources decklink | awk -F'[][]' '{print $2}' | grep -v "^$"
+    if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+        bmdcapture -h 2>&1 | grep "^->" | head -n 1 | sed 's/.*-> \(.*\) (.*/\1/'
+    else
+        "${FFMPEG_BIN}" -nostdin -v 0 -sources decklink | awk -F'[][]' '{print $2}' | grep -v "^$"
+    fi
 }
 GTKDIALOG_FUNCTION_DOC
 )
@@ -423,6 +428,9 @@ if [[ -f "${CONFIG_FILE}" ]] ; then
     # set defaults if not set by config file
     if [[ -z "${FFV1_SLICE_CHOICE}" ]] ; then
         FFV1_SLICE_CHOICE="16"
+    fi
+    if [[ -z "${DECKLINK_UTILITY_CHOICE}" ]] ; then
+        DECKLINK_UTILITY_CHOICE="ffmpeg"
     fi
 else
     _report -d "Initiatizing the configuration file at ${CONFIG_FILE}."
@@ -453,6 +461,10 @@ _gtk_vbox_list() {
                   <action type="refresh">VRECORD_OUTPUT_NAME</action>'
         elif  [[ "${VARIABLE_NAME}" == "AUDIO_MODE_CODEC_CHOICE" ]] ; then
             echo '<action type="refresh">VRECORD_OUTPUT_NAME</action>'
+        elif  [[ "${VARIABLE_NAME}" == "DECKLINK_UTILITY_CHOICE" ]] ; then
+          echo '<action condition="command_is_true( [ \"$DECKLINK_UTILITY_CHOICE\" = \"bmdcapture\" ] && echo true)">disable:TIMECODE_CHOICE</action>
+                <action condition="command_is_true( [ \"$DECKLINK_UTILITY_CHOICE\" != \"bmdcapture\" ] && echo true)">enable:TIMECODE_CHOICE</action>
+                <action type="refresh">VRECORD_OUTPUT_NAME</action>'
         fi
     }
 
@@ -692,6 +704,7 @@ DECKLINK_INPUT_GUI=$(cat << DECKLINK_FORM
 <frame Decklink input options>
     <vbox>
         <hbox space-expand="true">
+            $(_gtk_vbox_list "DECKLINK_UTILITY_CHOICE"  "100" "Select Input Utility"          "${DECKLINK_UTILITIES[@]}")
             $(_gtk_vbox_list "DECKLINK_INPUT_CHOICE"    "160" "Select Video Card"             "${DECKLINK_DEVICES[@]}")
             $(_gtk_vbox_list "VIDEO_INPUT_CHOICE"       "100" "Select Video Input"            "${VIDEO_INPUT_OPTIONS[@]}")
             $(_gtk_vbox_list "AUDIO_INPUT_CHOICE"       "200" "Select Audio Input"            "${AUDIO_INPUT_OPTIONS[@]}")
@@ -1246,14 +1259,29 @@ _passthrough_mode(){
     if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
         if [[ "${MEDIA_PLAYER_CHOICE}" = "mpv" ]] ; then
             _check_mpv
+            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+                bmdcapture "${GRAB_INPUT[@]}"
+            else
+                # TO INDENT
             "${FFMPEG_BIN}" -nostats "${GRAB_INPUT[@]}" 2> >(tee "${VRECORD_INPUT_TMP}" 1>&2) \
-            "${PIPE_OUTPUT[@]}" | \
+            "${PIPE_OUTPUT[@]}"
+            fi | \
             mpv "${MPVOPTS[@]}" --title="${WINDOW_NAME}" -
         elif [[ "${PLAYBACKVIEW_CHOICE_PASS}" = "Audio + Video" ]] ; then
-                "${FFMPEG_BIN}" -nostdin -hide_banner -nostats "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> "${VRECORD_INPUT_TMP}" | \
+            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+                bmdcapture "${GRAB_INPUT[@]}"
+            else
+                "${FFMPEG_BIN}" -nostdin -hide_banner -nostats "${GRAB_INPUT[@]}" "${PIPE_OUTPUT[@]}" 2> "${VRECORD_INPUT_TMP}"
+            fi | \
                 "${FFPLAY_BIN}" -window_title "${WINDOW_NAME}" -f lavfi "movie='pipe\:0':${PLAYBACKFILTER}"
         else
+            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+                bmdcapture "${GRAB_INPUT[@]}" | \
+                    "${FFPLAY_BIN}" - -window_title "${WINDOW_NAME}" -vf "${PLAYBACKFILTER}"
+            else
+                # TO INDENT
             "${FFPLAY_BIN}" "${FFPLAY_OPTIONS[@]}" 2> >(tee "${VRECORD_INPUT_TMP}" 1>&2)
+            fi
         fi
     elif [[ "${DEVICE_INPUT_CHOICE}" = "1" ]] ; then
         avfctl "${GRAB_INPUT[@]}" | "${FFPLAY_BIN}" -window_title "${WINDOW_NAME}" -
@@ -1405,15 +1433,15 @@ _lookup_choice(){
     esac
     case "${1}" in
         # video inputs
-        "Composite") VIDEO_INPUT="composite" ;;
-        "SDI")       VIDEO_INPUT="sdi" ;;
-        "Component") VIDEO_INPUT="component" ;;
-        "S-Video")   VIDEO_INPUT="s_video" ;;
+        "Composite") VIDEO_INPUT="composite" ; BMD_VIDEO_INPUT="1" ;;
+        "SDI")       VIDEO_INPUT="sdi";        BMD_VIDEO_INPUT="4" ;;
+        "Component") VIDEO_INPUT="component";  BMD_VIDEO_INPUT="2" ;;
+        "S-Video")   VIDEO_INPUT="s_video";    BMD_VIDEO_INPUT="6" ;;
 
         # audio inputs
-        "Analog")                  AUDIO_INPUT="analog" ;;
-        "SDI Embedded Audio")      AUDIO_INPUT="embedded" ;;
-        "Digital Audio (AES/EBU)") AUDIO_INPUT="aes_ebu" ;;
+        "Analog")                  AUDIO_INPUT="analog" ;   BMD_AUDIO_INPUT="1" ;;
+        "SDI Embedded Audio")      AUDIO_INPUT="embedded" ; BMD_AUDIO_INPUT="2"  ;;
+        "Digital Audio (AES/EBU)") AUDIO_INPUT="aes_ebu" ;  BMD_AUDIO_INPUT="3"  ;;
 
         # container
         "QuickTime")
@@ -1473,8 +1501,8 @@ _lookup_choice(){
             SUFFIX="_huff" ;;
 
         # video pixel format and bit depth
-        "10 bit") PIXEL_FORMAT="yuv422p10" ;;
-        "8 bit")  PIXEL_FORMAT="uyvy422" ;;
+        "10 bit") PIXEL_FORMAT="yuv422p10" ; BMD_PIXEL_FORMAT="yuv10" ;;
+        "8 bit")  PIXEL_FORMAT="uyvy422" ;   BMD_PIXEL_FORMAT="yuv8" ;;
 
         # audio codec
         "24-bit PCM")
@@ -1548,6 +1576,9 @@ _lookup_choice(){
         # video standard
         "NTSC")
             STANDARD="ntsc"
+            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+                BMD_STANDARD="$(bmdcapture -h 2>&1 | grep "NTSC.*29.97" | cut -d: -f 1 | sed 's/ //g' | head -n 1)"
+            fi
             DECKLINK_FPS="30000/1001"
             if [[ "${VIDEO_CODEC_CHOICE}" = "h264" ]] ; then
                 RECORDINGFILTER="crop=w=720:h=480:x=0:y=4,setsar=40/27,setdar=4/3"
@@ -1560,6 +1591,9 @@ _lookup_choice(){
             MIDDLEOPTIONS+=(-colorspace smpte170m) ;;
         "PAL")
             STANDARD="pal "
+            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+                BMD_STANDARD="$(bmdcapture -h 2>&1 | grep "PAL.*25" | cut -d: -f 1 | sed 's/ //g' | head -n 1)"
+            fi
             DECKLINK_FPS="25000/1000"
             if [[ "${VIDEO_CODEC_CHOICE}" = "h264" ]] ; then
                 RECORDINGFILTER="setsar=16/15,setdar=4/3"
@@ -1842,6 +1876,7 @@ drawgrid=w=32:h=32:t=1:c=white@0.1,\
 drawgrid=w=256:h=256:t=1:c=white@0.2"
 
 # list of selections for each vrecord option
+DECKLINK_UTILITIES=("ffmpeg" "bmdcapture")
 VIDEO_INPUT_OPTIONS=("Composite" "SDI" "Component" "S-Video")
 AUDIO_INPUT_OPTIONS=("Analog" "SDI Embedded Audio" "Digital Audio (AES/EBU)")
 CONTAINER_OPTIONS=("QuickTime" "Matroska" "AVI" "MXF" "MP4")
@@ -1910,6 +1945,7 @@ _review_option(){
 }
 
 if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
+    _review_option -n "DECKLINK_UTILITY_CHOICE" "${DECKLINK_UTILITIES[@]}"
     _review_option "VIDEO_INPUT_CHOICE" "${VIDEO_INPUT_OPTIONS[@]}"
     _review_option "AUDIO_INPUT_CHOICE" "${AUDIO_INPUT_OPTIONS[@]}"
     _review_option "VIDEO_BIT_DEPTH_CHOICE" "${VIDEO_BITDEPTH_OPTIONS[@]}"
@@ -1966,6 +2002,18 @@ if [[ -n "${ALT_INPUT}" ]] ; then
     GRAB_INPUT+=("${EXTRAINPUTOPTIONS[@]}")
     GRAB_INPUT+=(-i "${ALT_INPUT}")
 elif [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
+    if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+        GRAB_INPUT+=(-A "${BMD_AUDIO_INPUT}")
+        GRAB_INPUT+=(-V "${BMD_VIDEO_INPUT}")
+        GRAB_INPUT+=(-m "${BMD_STANDARD}")
+        GRAB_INPUT+=(-c 8)
+        GRAB_INPUT+=(-s 32)
+        GRAB_INPUT+=(-p "${BMD_PIXEL_FORMAT}")
+        GRAB_INPUT+=(-F "matroska")
+        GRAB_INPUT+=(-d "1")
+        GRAB_INPUT+=(-f pipe:1)
+    else
+    ## TO INDENT
     _set_ffmpeg_loglevel
     GRAB_INPUT+=(-f decklink)
     GRAB_INPUT+=(-draw_bars 0)
@@ -1977,6 +2025,7 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     GRAB_INPUT+=(-raw_format "${PIXEL_FORMAT}")
     GRAB_INPUT+=("${EXTRAINPUTOPTIONS[@]}")
     GRAB_INPUT+=(-i "${DECKLINK_INPUT_CHOICE}")
+    fi
 elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     AVFCTL_INPUT_INDEX="$(echo "${AVFCTL_INPUT_CHOICE}" | cut -c 2)"
     GRAB_INPUT+=(-device "${AVFCTL_INPUT_INDEX}")
@@ -2239,6 +2288,21 @@ _report -d "Close the playback window to stop recording."
 # vrecord process!
 if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     # DEVICE_INPUT_CHOICE=0 is decklink, other DEVICE_INPUT_CHOICE values don't yet use such filtering
+    if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+        RECORD_COMMAND=(bmdcapture)
+        # TO DO adjust TIME_LIMIT for bmdcapture
+        RECORD_COMMAND+=("${GRAB_INPUT[@]}")
+        FF_RECORD_COMMAND=("${FFMPEG_BIN}" -nostdin -nostats "${TIME_LIMIT[@]}")
+        FF_RECORD_COMMAND+=(-i -)
+        if [[ -n "${VIDEOCODECNAME}" ]] ; then
+            MIDDLEOPTIONS+=(-metadata:s:v:0 encoder="${VIDEOCODECNAME}")
+        fi
+        FF_RECORD_COMMAND+=("${MIDDLEOPTIONS[@]}")
+        FF_RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
+        FF_RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
+        FF_RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
+    else
+        #TO DO indent
     RECORD_COMMAND=("${FFMPEG_BIN}")
     RECORD_COMMAND+=(-nostdin -nostats "${TIME_LIMIT[@]}" "${GRAB_INPUT[@]}")
     if [[ -n "${VIDEOCODECNAME}" ]] ; then
@@ -2248,6 +2312,7 @@ if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
     RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}; ${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
     RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
     RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" "${PIPE_OUTPUT[@]}")
+    fi
 elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     RECORD_COMMAND=(avfctl)
     RECORD_COMMAND+=("${GRAB_INPUT[@]}")

--- a/vrecord
+++ b/vrecord
@@ -2330,6 +2330,7 @@ if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
         _check_mpv
         PLAYER_COMMAND=(mpv "${MPVOPTS[@]}" --title="${WINDOW_NAME}" -)
     else
+        _set_ffplay_options
         PLAYER_COMMAND=("${FFPLAY_BIN}" "${FFPLAY_OPTIONS[@]}")
     fi
 elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
@@ -2341,6 +2342,7 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
     FF_RECORD_COMMAND+=(-map 0:v -c copy)
     FF_RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
     FF_RECORD_COMMAND+=(-map 0:v -f rawvideo -c copy -)
+    _set_ffplay_options
     PLAYER_COMMAND=("${FFPLAY_BIN}" -)
 elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
     VRECORD_STEPS="2"
@@ -2349,11 +2351,11 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
     RECORD_COMMAND+=("${MIDDLEOPTIONS[@]}")
     RECORD_COMMAND+=(-f "${FORMAT}" -filter_complex "${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" "${VRECORD_OUTPUT}")
     RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}" -filter_complex "${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}" "${PIPE_OUTPUT[@]}")
+    _set_ffplay_options
     PLAYER_COMMAND=("${FFPLAY_BIN}" -f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}")
 else
     _report_unexpected_error DEVICE_INPUT_CHOICE
 fi
-_set_ffplay_options
 if [[ "${VRECORD_STEPS}" = "2" ]] ; then
     _writeingestlog "Capture-Record command" "${FF_RECORD_COMMAND[@]}"
     _writeingestlog "Playback command" "${PLAYER_COMMAND[@]}"

--- a/vrecord
+++ b/vrecord
@@ -404,6 +404,7 @@ GTKDIALOG_FUNCTION_DOC
 )
 
 # optional dependency checks
+BMDTOOLS_INSTALLED="$(if command -v bmdcapture >/dev/null ; then echo true ; else echo false ; fi)"
 DECKCONTROL_INSTALLED="$(if command -v deckcontrol >/dev/null ; then echo true ; else echo false ; fi)"
 GNUPLOT_INSTALLED="$(if command -v gnuplot >/dev/null ; then echo true ; else echo false ; fi)"
 MEDIACONCH_INSTALLED="$(if command -v mediaconch >/dev/null ; then echo true ; else echo false ; fi)"
@@ -581,6 +582,14 @@ PLAYBACK_OPT_GUI="
 
 OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
 <frame Optional Tools>
+  <hbox>
+        <text>
+            <label>bmdtools: </label>
+        </text>
+        <pixmap stock-icon-size="1" tooltip-text="If bmdtools is installed, vrecord can offer bmdcapture as an alternate method (to ffmpeg) to receive an input from a Blackmagic capture device.">
+            <input file stock="$(if $BMDTOOLS_INSTALLED ; then echo gtk-yes ; else echo gtk-no ; fi)"></input>
+        </pixmap>
+    </hbox>
     <hbox>
         <text>
             <label>deckcontrol: </label>

--- a/vrecord
+++ b/vrecord
@@ -2102,7 +2102,7 @@ _set_ffplay_options(){
         FFPLAY_OPTIONS+=(-i -)
     fi
     FFPLAY_OPTIONS+=(-window_title "${WINDOW_NAME}")
-    if [[ ! -z "${PLAYBACKFILTER}" ]] ; then
+    if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] && [[ ! -z "${PLAYBACKFILTER}" ]] ; then
         FFPLAY_OPTIONS+=(-vf "${PLAYBACKFILTER}")
     fi
     FFPLAY_OPTIONS+=(-af "channelmap=0|1:stereo")

--- a/vrecord
+++ b/vrecord
@@ -2355,12 +2355,12 @@ elif [[ "${DEVICE_INPUT_CHOICE}" = 1 ]] ; then
         2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
         "${FF_RECORD_COMMAND[@]}" \
         2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) | \
-        "${FFPLAY_BIN}" -window_title "${WINDOW_NAME}" -
+        "${FFPLAY_BIN}" -
 elif [[ "${DEVICE_INPUT_CHOICE}" = 2 ]] ; then
     "${RECORD_COMMAND[@]}" \
         2> >(tee "${FULL_CAPTURE_LOG}" "${VRECORD_INPUT_TMP}" 1>&2) \
         | \
-        "${FFPLAY_BIN}" -window_title "${WINDOW_NAME}" -f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}"
+        "${FFPLAY_BIN}" -f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}"
 fi
 # capture errors from components of recording pipe
 P1_ERR="${PIPESTATUS[0]}"

--- a/vrecord
+++ b/vrecord
@@ -22,7 +22,7 @@ files.
 
 Dependencies: cowsay, amiaopensource/amiaos/decklinksdk,
   amiaopensource/amiaos/ffmpegdecklink, amiaopensource/amiaos/gtkdialog,
-  freetype, sdl and xmlstarlet
+  and xmlstarlet
 Optional Dependencies: deckcontrol, gnuplot, mediaconch, mkvtoolnix, mpv, qcli
 
 Usage: ${SCRIPTNAME} [ -g | -e | -r | -p | -a | -x | -v | -h ] [IDENTIFIER]

--- a/vrecord
+++ b/vrecord
@@ -400,6 +400,12 @@ _get_output_filename(){
 
     echo "${DIR}/${PREFIX}${ID}${SUFFIX}.${EXTENSION}"
 }
+
+_get_decklink_inputs(){
+    # get information on what input device options are available
+    #unset DECKLINK_DEVICES
+    "${FFMPEG_BIN}" -nostdin -v 0 -sources decklink | awk -F'[][]' '{print $2}' | grep -v "^$"
+}
 GTKDIALOG_FUNCTION_DOC
 )
 
@@ -430,7 +436,11 @@ _gtk_vbox_list() {
     shift 3
     OPTION_LIST=("${@}")
     SELECTION="$(_get_index_of_value "${!VARIABLE_NAME}" "${OPTION_LIST[@]}")"
-    LIST="$(_expand_list2items "${OPTION_LIST[@]}")"
+    if [[ "${VARIABLE_NAME}" == "DECKLINK_INPUT_CHOICE" ]] ; then
+        LIST="<input>_get_decklink_inputs</input>"
+    else
+        LIST="$(_expand_list2items "${OPTION_LIST[@]}")"
+    fi
 
     _get_list_extras(){
         if [[ "${VARIABLE_NAME}" == "VIDEO_CODEC_CHOICE" ]] ; then
@@ -458,6 +468,13 @@ _gtk_vbox_list() {
             echo "<sensitive>$(if $MKVPROPEDIT_INSTALLED ; then echo true ; else echo false ; fi)</sensitive>"
         elif [[ "${VARIABLE_NAME}" == "QCTOOLSXML_CHOICE" ]] ; then
             echo "<sensitive>$(if $QCLI_INSTALLED ; then echo true ; else echo false ; fi)</sensitive>"
+        elif [[ "${VARIABLE_NAME}" == "DECKLINK_INPUT_CHOICE" ]] ; then
+            echo "
+            <button>
+                <label>Rescan</label>
+                <action type=\"clear\">DECKLINK_INPUT_CHOICE</action>
+                <action type=\"refresh\">DECKLINK_INPUT_CHOICE</action>
+            </button>"
         fi
     }
 


### PR DESCRIPTION
This is a work in progress PR to add bmdcapture as an alternative method for handling the input from decklink cards. In a way, this adds back an option that was replaced in https://github.com/amiaopensource/vrecord/commit/8f6a31be7cbab07ebceb85fc076ef1cb0338a5f4. Currently FFmpeg uses a device iterator that requires a more recent version of the decklink driver than bmdcapture requires. This means that bmdcapture can be used as an input with Decklink Desktop Video 10.8.1 whereas FFmpeg can't. @iamdamosuzuki notes that versions of the Decklink driver after version 10.8.1 break handling of some values of analog input.

This PR, offers an option in edit mode for using either ffmpeg or bmdcapture as an input handler; however, this PR currently only works with passthrough mode. Recording handling is not yet completed.