### PR TITLE
exit if no decklink input is found

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -335,6 +335,10 @@ _setup_vrecord_process(){
     # set up input and playback
     unset GRAB_INPUT
     GRAB_INPUT+=("${EXTRAINPUTOPTIONS[@]}")
+    if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] && [[ -z "${DECKLINK_INPUT_CHOICE}" ]] ; then
+        _report -w -t "The decklink input is not found."
+        exit 1
+    fi
     if [[ -n "${ALT_INPUT}" ]] ; then
         GRAB_INPUT+=(-i "${ALT_INPUT}")
     elif [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then


### PR DESCRIPTION
addressing https://github.com/amiaopensource/vrecord/issues/639

Now it just ends with 

```
Hit enter to start recording

Close the playback window to stop recording.
 2020-11-20T09:51:52 - The decklink input is not found.
```