### PR TITLE
Blackmagic dropped Intensity Shuttle

### DIFF
--- a/Resources/Documentation/hardware.md
+++ b/Resources/Documentation/hardware.md
@@ -6,7 +6,7 @@
   - [UltraStudio](https://www.blackmagicdesign.com/products/ultrastudiothunderbolt)
   - [DeckLink](https://www.blackmagicdesign.com/products/decklink), except for the DeckLink 4K Extreme card (see https://github.com/amiaopensource/vrecord/issues/209#issuecomment-360862657)
   - [Intensity Pro 4K](https://www.blackmagicdesign.com/products/intensitypro4k)
-  - [Intensity](https://www.blackmagicdesign.com/products/intensity)
+  - Intensity
   - [Teranex](https://www.blackmagicdesign.com/products/teranex)
   
   Please note that Blackmagic Mini Converters are not recommended, as they clip the video signal at broadcast levels.

--- a/Resources/Documentation/hardware.md
+++ b/Resources/Documentation/hardware.md
@@ -6,7 +6,6 @@
   - [UltraStudio](https://www.blackmagicdesign.com/products/ultrastudiothunderbolt)
   - [DeckLink](https://www.blackmagicdesign.com/products/decklink), except for the DeckLink 4K Extreme card (see https://github.com/amiaopensource/vrecord/issues/209#issuecomment-360862657)
   - [Intensity Pro 4K](https://www.blackmagicdesign.com/products/intensitypro4k)
-  - Intensity
   - [Teranex](https://www.blackmagicdesign.com/products/teranex)
   
   Please note that Blackmagic Mini Converters are not recommended, as they clip the video signal at broadcast levels.


### PR DESCRIPTION
- the product page at Blackmagic does not longer exist
- I suggest to keep the model in our list, because it’s still possible to buy it from various resellers