### PR TITLE
avoid bmdcapture if using a virtual file input

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -347,7 +347,7 @@ _setup_vrecord_process(){
     if [[ -n "${ALT_INPUT}" ]] ; then
         GRAB_INPUT+=(-i "${ALT_INPUT}")
     elif [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
-        if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+        if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] && [[ -z "${ALT_INPUT}" ]] ; then
             GRAB_INPUT+=(-A "${BMD_AUDIO_INPUT}")
             GRAB_INPUT+=(-V "${BMD_VIDEO_INPUT}")
             GRAB_INPUT+=(-m "${BMD_STANDARD}")
@@ -432,7 +432,7 @@ _setup_vrecord_process(){
     fi
     if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
         # DEVICE_INPUT_CHOICE=0 is decklink, other DEVICE_INPUT_CHOICE values don't yet use such filtering
-        if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+        if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] && [[ -z "${ALT_INPUT}" ]] ; then
             if [[ "${RUNTYPE}" = "record" ]] ; then
                 VRECORD_STEPS="3" # Steps: record | ff_record | player
             else
@@ -1588,7 +1588,7 @@ _lookup_choice(){
         # video standard
         "NTSC")
             STANDARD="ntsc"
-            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] && [[ -z "${ALT_INPUT}" ]] ; then
                 BMD_STANDARD="$(bmdcapture -h 2>&1 | grep "NTSC.*29.97" | cut -d: -f 1 | sed 's/ //g' | head -n 1)"
                 RECORDINGFILTER+="setfield=bff,"
             fi
@@ -1603,7 +1603,7 @@ _lookup_choice(){
             MIDDLEOPTIONS+=(-colorspace smpte170m) ;;
         "PAL")
             STANDARD="pal "
-            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] ; then
+            if [[ "${DECKLINK_UTILITY_CHOICE}" == "bmdcapture" ]] && [[ -z "${ALT_INPUT}" ]] ; then
                 BMD_STANDARD="$(bmdcapture -h 2>&1 | grep "PAL.*25" | cut -d: -f 1 | sed 's/ //g' | head -n 1)"
                 RECORDINGFILTER+="setfield=tff,"
             fi


### PR DESCRIPTION
This should allow the virtual input to work even if bmdcapture is selected.