### PR TITLE
Configuration window entry 'Technician' from config file is not shown…

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1191,6 +1191,7 @@ export MAIN_DIALOG='
                             <label>Name of the person digitizing this tape.</label>
                         </text>
                         <entry>
+                            <default>"'"${TECHNICIAN}"'"</default>
                             <variable>TECHNICIAN</variable>
                         </entry>
                     </vbox>


### PR DESCRIPTION
supersedes https://github.com/amiaopensource/vrecord/pull/675

@takahe, I took your comment and removed the change to vrecord_functions to save the ID value from recording to recording