### PR TITLE
Fixing a homebrew path issue

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -143,6 +143,12 @@ _setup_env_variables(){
             else
                 RESOURCE_PATH="$(brew --prefix vrecord)"
             fi
+        elif [[ "${PATH_CHECK}" = "/opt/homebrew/bin" ]] ; then
+            if [[ -d "/opt/homebrew/opt/vrecord" ]] ; then
+                RESOURCE_PATH="/opt/homebrew/opt/vrecord"
+            else
+                RESOURCE_PATH="$(brew --prefix vrecord)"
+            fi
         else
             RESOURCE_PATH="${SCRIPTDIR}/Resources"
         fi

--- a/vrecord
+++ b/vrecord
@@ -173,7 +173,7 @@ _setup_env_variables(){
         COMPUTER_PROCESSOR_COUNT="$(_parse_report "Number of Processors" "${HARDWARE_REPORT}")"
         COMPUTER_MEMORY="$(_parse_report "Memory" "${HARDWARE_REPORT}")"
         COMPUTER_SERIAL="$(_parse_report "Serial Number (system)" "${HARDWARE_REPORT}")"
-        CORE_COUNT="$(_parse_report "Total Number of Cores" "${HARDWARE_REPORT}")"
+        CORE_COUNT="$(_parse_report "Total Number of Cores" "${HARDWARE_REPORT}" | awk '{print $1}')"
         OPEN_COMMAND="open"
         ZCAT_COMMAND="gzcat"
         DECKLINK_DRIVER_PLIST="/Library/Extensions/DeckLink_Driver.kext/Contents/Info.plist"


### PR DESCRIPTION
should fix https://github.com/amiaopensource/vrecord/issues/686. Since homebrew installs moved from /usr/local to /opt/homebrew, vrecord is missing a bunch of resources when installed. Need a release after merging this.