### PR TITLE
Expand language support

### DIFF
--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -180,7 +180,7 @@ _get_avfctl_input_list(){
 
 _get_audio_device_list(){
     if [ "${OS_TYPE}" = "linux" ] ; then
-        arecord -l | grep card | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}'
+        arecord -l | grep "$card_var" | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}'
     elif [ "${OS_TYPE}" = "macOS" ] ; then
         "${FFMPEG_BIN}" -nostdin -hide_banner -f avfoundation -list_devices 1 -i dummy 2>&1 | grep -A 10 "AVFoundation audio devices" | grep -o "\[[0-9]\].*" | cut -d " " -f2-
     fi

--- a/vrecord
+++ b/vrecord
@@ -208,13 +208,23 @@ _setup_env_variables(){
 _get_lang(){
     #detects system language
     languages=( de en es fr hi id it jp nl sv vi zh )
-    language_scan=$(locale | head -n2)
+    language_scan1=$(locale | sed -n -e '1{p;q}')
     for i in "${languages[@]}" ; do
-        if [[ "${language_scan}" == *"${i}"* ]] ; then
+        if [[ "${language_scan1}" == *"${i}"* ]] ; then
             system_language="${i}"
             break
         fi
     done
+
+    if [[ -z "${system_language}" ]] ; then
+        language_scan2=$(locale | sed -n -e '2{p;q}' | cut -d ':' -f1)
+        for i in "${languages[@]}" ; do
+        if [[ "${language_scan2}" == *"${i}"* ]] ; then
+            system_language="${i}"
+            break
+        fi
+        done
+    fi
     if [[ -z "${system_language}" ]] ; then system_language='en'; fi
 }
 

--- a/vrecord
+++ b/vrecord
@@ -232,7 +232,7 @@ _set_lang_variables(){
     if [[ "${system_language}" == 'en' ]] ; then
         card_var='card'
     elif [[ "${system_language}" == 'de' ]] ; then
-        card_var='karte'
+        card_var='Karte'
     elif [[ "${system_language}" == 'es' ]] ; then
         card_var='tarjeta'
     elif [[ "${system_language}" == 'fr' ]] ; then
@@ -254,6 +254,7 @@ _set_lang_variables(){
     elif [[ "${system_language}" == 'zh' ]] ; then
         card_var='card'
     fi
+    _include_var card_var
 }
 
 _gather_ffmpeg_vars(){

--- a/vrecord
+++ b/vrecord
@@ -205,6 +205,47 @@ _setup_env_variables(){
     fi
 }
 
+_get_lang(){
+    #detects system language
+    languages=( de en es fr hi id it jp nl sv vi zh )
+    language_scan=$(locale | head -n2)
+    for i in "${languages[@]}" ; do
+        if [[ "${language_scan}" == *"${i}"* ]] ; then
+            system_language="${i}"
+            break
+        fi
+    done
+    if [[ -z "${system_language}" ]] ; then system_language='en'; fi
+}
+
+_set_lang_variables(){
+    if [[ "${system_language}" == 'en' ]] ; then
+        card_var='card'
+    elif [[ "${system_language}" == 'de' ]] ; then
+        card_var='karte'
+    elif [[ "${system_language}" == 'es' ]] ; then
+        card_var='tarjeta'
+    elif [[ "${system_language}" == 'fr' ]] ; then
+        card_var='carte'
+    elif [[ "${system_language}" == 'hi' ]] ; then
+        card_var='card'
+    elif [[ "${system_language}" == 'id' ]] ; then
+        card_var='card'
+    elif [[ "${system_language}" == 'it' ]] ; then
+        card_var='scheda'
+    elif [[ "${system_language}" == 'jp' ]] ; then
+        card_var='カード'
+    elif [[ "${system_language}" == 'nl' ]] ; then
+        card_var='kaart'
+    elif [[ "${system_language}" == 'sv' ]] ; then
+        card_var='kort'
+    elif [[ "${system_language}" == 'vi' ]] ; then
+        card_var='card'
+    elif [[ "${system_language}" == 'zh' ]] ; then
+        card_var='card'
+    fi
+}
+
 _gather_ffmpeg_vars(){
     CAPTURELOGSUFFIX="_vrecord_input.log"
     TIMECODELOGSUFFIX="_frame_timecodes.txt"
@@ -2179,11 +2220,13 @@ fi
 _get_decklink_inputs
 _get_avfoundation_inputs
 _get_avfctl_inputs
+_get_lang
+_set_lang_variables
 
 if [[ "${OS_TYPE}" = "linux" ]] ; then
     while read audio_device ; do
         AUDIO_DEVICES+=("${audio_device}")
-    done < <(arecord -l | grep card | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}')
+    done < <(arecord -l | grep "${card_var}" | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}')
 elif [[ "${OS_TYPE}" = "macOS" ]] ; then
     AUDIO_DEVICES=("${AVFOUNDATION_DEVICES[@]}")
 fi


### PR DESCRIPTION
This accounts for the output of audio device parsing via `arecord -l` in linux being multi-lingual.  Will still need some work as non-roman characters (i.e. カード) still don't seem to be parsing correctly, but should fix https://github.com/amiaopensource/vrecord/issues/709 and hopefully accounts for a lot of potential users. Mac functionality doesn't appear to be impacted by language.