### PR TITLE
grep for brackets in arecord output

### DIFF
--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -192,7 +192,7 @@ _get_avfctl_input_list(){
 
 _get_audio_device_list(){
     if [ "${OS_TYPE}" = "linux" ] ; then
-        arecord -l | grep card | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}'
+        arecord -l | grep -E '\[.*\]' | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}'
     elif [ "${OS_TYPE}" = "macOS" ] ; then
         "${FFMPEG_BIN}" -nostdin -hide_banner -f avfoundation -list_devices 1 -i dummy 2>&1 | grep -A 10 "AVFoundation audio devices" | grep -o "\[[0-9]\].*" | cut -d " " -f2-
     fi


### PR DESCRIPTION
Think this might be an easier solution to https://github.com/amiaopensource/vrecord/issues/709. Works on two computers on my end and with output of `arecord -l` examples I can see posted online.

Doesn't help if we have other grep language issues somewhere, but cross that bridge when we get there?