### PR TITLE
Change audio device parsng

### DIFF
--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -192,7 +192,7 @@ _get_avfctl_input_list(){
 
 _get_audio_device_list(){
     if [ "${OS_TYPE}" = "linux" ] ; then
-        arecord -l | grep -E '\[.*\]' | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}'
+        arecord -l | grep -E '\[.*\]' | cut -d ':' -f1-2 | awk '{$1=$1;print}'
     elif [ "${OS_TYPE}" = "macOS" ] ; then
         "${FFMPEG_BIN}" -nostdin -hide_banner -f avfoundation -list_devices 1 -i dummy 2>&1 | grep -A 10 "AVFoundation audio devices" | grep -o "\[[0-9]\].*" | cut -d " " -f2-
     fi

--- a/vrecord
+++ b/vrecord
@@ -605,10 +605,11 @@ _get_avfctl_inputs(){
 }
 
 _get_audio_dev_num(){
-    AUDIO_DEV_NUM=0
-    while [[ "${AUDIO_DEV_CHOICE}" != "${AUDIO_DEVICES[${AUDIO_DEV_NUM}]}" ]] ; do
-        AUDIO_DEV_NUM=$(( ${AUDIO_DEV_NUM} + 1 ))
-    done
+    if [[ $(echo ${AUDIO_DEVICES[@]} | fgrep -w "$AUDIO_DEV_CHOICE") ]]
+    then
+      AUDIO_DEV_FULL=$(printf '%s\n' "${AUDIO_DEVICES[@]}" | fgrep "$AUDIO_DEV_CHOICE")
+      AUDIO_DEV_NUM="$(echo "$AUDIO_DEV_FULL" | cut -d ':' -f1 | sed 's|card ||g'),$(echo "$AUDIO_DEV_FULL" | rev | cut -d ' ' -f1)"
+    fi
 }
 
 _set_up_edit_form() {
@@ -2183,7 +2184,7 @@ _get_avfctl_inputs
 if [[ "${OS_TYPE}" = "linux" ]] ; then
     while read audio_device ; do
         AUDIO_DEVICES+=("${audio_device}")
-    done < <(arecord -l | grep card | cut -d ':' -f2 | cut -d ',' -f1 | awk '{$1=$1;print}')
+    done < <(arecord -l | grep card | cut -d ':' -f1-2 | awk '{$1=$1;print}')
 elif [[ "${OS_TYPE}" = "macOS" ]] ; then
     AUDIO_DEVICES=("${AVFOUNDATION_DEVICES[@]}")
 fi

--- a/vrecord
+++ b/vrecord
@@ -605,9 +605,9 @@ _get_avfctl_inputs(){
 }
 
 _get_audio_dev_num(){
-    if [[ $(echo ${AUDIO_DEVICES[@]} | fgrep -w "$AUDIO_DEV_CHOICE") ]]
+    if [[ $(echo ${AUDIO_DEVICES[@]} | grep -F -w "$AUDIO_DEV_CHOICE") ]]
     then
-      AUDIO_DEV_FULL=$(printf '%s\n' "${AUDIO_DEVICES[@]}" | fgrep "$AUDIO_DEV_CHOICE")
+      AUDIO_DEV_FULL=$(printf '%s\n' "${AUDIO_DEVICES[@]}" | grep -F "$AUDIO_DEV_CHOICE")
       AUDIO_DEV_NUM="$(echo "$AUDIO_DEV_FULL" | cut -d ':' -f1 | sed 's|card ||g'),$(echo "$AUDIO_DEV_FULL" | rev | cut -d ' ' -f1)"
     fi
 }


### PR DESCRIPTION
This changes how vrecord parses the output of `arecord` to find capture device numbers for ffmpeg. Should address the issue in https://github.com/amiaopensource/vrecord/issues/753.

Currently the `_get_audio_dev_num` compares AUDIO_DEV_CHOICE to AUDIO_DEVICES in a convoluted manner - this was done with the hope of ultimately parsing the displayed audio devices in the GUI differently to make things a little more visually appealing.

For the time being though, the device list in the GUI needs to be the same as the device list on the back end to facilitate saved settings displaying as selected in the GUI, so leaving as-is in the interests of resolving the parsing issue.