### PR TITLE
Allow different output from `avfctl -list_devices`

### DIFF
--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -186,7 +186,7 @@ _get_avfctl_input_list(){
     if [ "${OS_TYPE}" = "linux" ] ; then
         echo "Default DV Device"
     else
-        avfctl -list_devices 2>&1 | grep -A 10 "Devices:" | grep -o "\[[0-9]\].*"
+        avfctl -list_devices 2>&1 | grep -A 10 "Devices:" | sed -e 's/.*avfctl\[[0-9]*:[0-9]*\] //'
     fi
 }
 

--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -186,7 +186,7 @@ _get_avfctl_input_list(){
     if [ "${OS_TYPE}" = "linux" ] ; then
         echo "Default DV Device"
     else
-        avfctl -list_devices 2>&1 | grep -A 10 "Devices:" | sed -e 's/.*avfctl\[[0-9]*:[0-9]*\] //'
+        avfctl -list_devices 2>&1 | grep -v "Devices:" | sed -e 's/.*avfctl\[[0-9]*:[0-9]*\] //'
     fi
 }
 

--- a/vrecord
+++ b/vrecord
@@ -595,7 +595,7 @@ _get_avfctl_inputs(){
     unset AVFCTL_DEVICES
     while read avfctl_device ; do
         AVFCTL_DEVICES+=("${avfctl_device}")
-    done < <(avfctl -list_devices 2>&1 | grep -A 10 "Devices:" | grep -o "\[[0-9]\].*")
+    done < <(avfctl -list_devices 2>&1 | grep -A 10 "Devices:" | sed -e 's/.*avfctl\[[0-9]*:[0-9]*\] //')
     if [[ "${#AVFCTL_DEVICES[@]}" = 1 ]] ; then # default to first input if only one
         AVFCTL_INPUT_CHOICE="${AVFCTL_DEVICES[0]}"
     fi

--- a/vrecord
+++ b/vrecord
@@ -595,7 +595,7 @@ _get_avfctl_inputs(){
     unset AVFCTL_DEVICES
     while read avfctl_device ; do
         AVFCTL_DEVICES+=("${avfctl_device}")
-    done < <(avfctl -list_devices 2>&1 | grep -A 10 "Devices:" | sed -e 's/.*avfctl\[[0-9]*:[0-9]*\] //')
+    done < <(avfctl -list_devices 2>&1 | grep -v "Devices:" | sed -e 's/.*avfctl\[[0-9]*:[0-9]*\] //')
     if [[ "${#AVFCTL_DEVICES[@]}" = 1 ]] ; then # default to first input if only one
         AVFCTL_INPUT_CHOICE="${AVFCTL_DEVICES[0]}"
     fi


### PR DESCRIPTION
**Summary:** Between two MacOS computers, one with an Intel CPU and one with an M1 CPU the same deck will return different results to `avfctl` that fails a regular expression check in `vrecord` and `Resources/vrecord_functions` which then fails to display any AV decks in the user interface. _(Note: The CPU model may be irrelevant, but I'm pointing out that there are differences from how `avfctl` reports attached devices)_

On the M1 machine, we have:
```
$ avfctl -list devices
2023-08-22 16:40:29.062 avfctl[17361:1718240] Devices:
2023-08-22 16:40:29.063 avfctl[17361:1718240] [0] JVC DV
```

On the Intel, the same deck is displayed differently.
```
$ avfctl -list_devices
2023-08-22 16:46:05.739 avfctl[12778:52178] Devices:
2023-08-22 16:46:05.740 avfctl[12778:52178] [0 - 0x80884f44021cfc] JVC DV
```

`avfctl` is the same version on both computers.

[Line 598 of vrecord](https://github.com/amiaopensource/vrecord/blob/0831f7cea2091bb938ba3934bfda49507aef7265/vrecord#L598) has a command pipeline with a regular expression `grep -o "\[[0-9]\].*"` which assumes the M1 style of output. The Intel output fails the regular expression and returns nothing to `vrecord` and no decks are listed.

A better solution is to use `grep -v` and `sed` to remove the parts of the output we don't want. Updating Line 598 with the following solves the problem:

```
avfctl -list_devices 2>&1 | grep -v "Devices:" | sed -e 's/.*avfctl\[[0-9]*:[0-9]*\] //'
```
**Second problem:** This same command is [duplicated](https://github.com/amiaopensource/vrecord/blob/0831f7cea2091bb938ba3934bfda49507aef7265/Resources/vrecord_functions#L189) in the function `Resources/vrecord_functions:_get_avfctl_input_list()`. The `vrecord` main script should be using this, instead of repeating the commands. If it's not possible to refactor the code, then replace the same faulty `grep` with `sed` from above.

This pull request addresses both.