### PR TITLE
Make monitoring audiomapping more representative

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -565,7 +565,7 @@ _setup_vrecord_process(){
             if [[ -n "${PLAYBACKFILTER}" ]] ; then
                 FFPLAY_OPTIONS+=(-vf "${PLAYBACKFILTER}")
             fi
-            FFPLAY_OPTIONS+=(-af "channelmap=0|1:stereo")
+            FFPLAY_OPTIONS+=(-af "${AUDIO_PLAY_MAP}")
         fi
         if [[ "${MONITOR_AUDIO_CHOICE}" = "No" ]] ; then
             FFPLAY_OPTIONS+=(-an)
@@ -1650,13 +1650,16 @@ _lookup_choice(){
         # audio mappings
         "2 Stereo Tracks (Channels 1 & 2 -> 1st Track Stereo, Channels 3 & 4 -> 2nd Track Stereo)")
             AUDIOMAP="[0:a:0]pan=stereo| c0=c0 | c1=${PHASE_VALUE_2}c1[stereo1];[0:a:0]pan=stereo| c0=c2 | c1=${PHASE_VALUE_4}c3[stereo2]"
+            AUDIO_PLAY_MAP="pan=quad|c0=c0|c1=${PHASE_VALUE_2}c1|c2=c2|c3=${PHASE_VALUE_4}c3"
             AUDIO_CHANNEL_MAP+=(-map "[stereo1]")
             AUDIO_CHANNEL_MAP+=(-map "[stereo2]") ;;
         "1 Stereo Track (From Channels 1 & 2)")
             AUDIOMAP="[0:a:0]pan=stereo| c0=c0 | c1=${PHASE_VALUE_2}c1[stereo1]"
+            AUDIO_PLAY_MAP="pan=stereo|c0=c0|c1=${PHASE_VALUE_2}c1"
             AUDIO_CHANNEL_MAP+=(-map "[stereo1]") ;;
         "1 Stereo Track (From Channels 3 & 4)")
             AUDIOMAP="[0:a:0]pan=stereo| c0=c2 | c1=${PHASE_VALUE_2}c3[stereo1]"
+            AUDIO_PLAY_MAP="pan=stereo|c0=c2|c1=${PHASE_VALUE_2}c3"
             AUDIO_CHANNEL_MAP+=(-map "[stereo1]") ;;
         "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono")
             AUDIOMAP="[0:a:0]pan=mono| c0=c0[mono1];[0:a:0]pan=mono| c0=${PHASE_VALUE_2}c1[mono2]"
@@ -1679,7 +1682,7 @@ _lookup_choice(){
             AUDIO_CHANNEL_MAP+=(-map "[mono1]") ;;
         "Stereo")
             AUDIOMAP="[0:a:0]pan=stereo| c0=c0 | c1=${PHASE_VALUE_2}c1[stereo1]"
-            PASSTHROUGH_MAP="pan=stereo|c0=c0|c1=c1"
+            PASSTHROUGH_MAP="pan=stereo|c0=c0|c1=${PHASE_VALUE_2}c1"
             AUDIO_CHANNEL_MAP+=(-map "[stereo1]") ;;
         # Audio mode sample rate options
         "96 kHz")
@@ -1769,7 +1772,7 @@ ${AP_MAP}" ;;
         "Audio + Video")
 if [[ "${RUNTYPE}" = "record" ]] ; then
     PLAYBACKFILTER="streams=dv+da[vid][aud],\
-    [aud]asplit=2[aud1][out1];\
+    [aud]${AUDIO_PLAY_MAP},asplit=2[aud1][out1];\
     [aud1]showvolume=t=0:dm=5400:rate=${DECKLINK_FPS}[aud2];\
     [vid]${PLAYBACK_FILTER_ADJUSTMENT}split=5[a][b][c][d][e];\
     [a]copy${TIMECODE_OVERLAY}[a1];\
@@ -1795,7 +1798,7 @@ else
         PHASE_MAP="[a]pan=stereo|c0=c0|c1=c1,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[phase1],\
         [aa]pan=stereo|c0=c2|c1=c3,aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=400x200:bg=black:fg1=0x99999999,drawbox=x=0:y=100:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_3_4}[phase2]"
         SPECTRUM_SIZE='755x265'
-        PAN="pan=quad|c0=c0|c1=${PHASE_VALUE_2}c1|c2=c2|c3=${PHASE_VALUE_4}c3"
+        PAN="${AUDIO_PLAY_MAP}"
     else
         PRINT_PHASE=",drawtext=fontfile=${DEFAULTFONT}:box=1:text=Phase\\\: %{metadata\\\:lavfi.aphasemeter.phase}:x=135:y=380:fontcolor=black"
         PRINT_CHANNELS_1_2=",drawtext=fontfile=${DEFAULTFONT}:text=Ch.1/2:x=10: y=10:fontcolor=white"
@@ -1805,7 +1808,7 @@ else
         PHASE_LOCATION='x=135:y=380'
         PHASE_MAP="[a]aphasemeter=video=0,adrawgraph=lavfi.aphasemeter.phase:max=1:min=-1:size=320x400:bg=black:fg1=0x99999999,drawbox=x=0:y=200:w=400:c=white:h=1${PRINT_PHASE}${PRINT_CHANNELS_1_2}[a1]"
         SPECTRUM_SIZE='1155x200'
-        PAN="pan=stereo|c0=c0|c1=${PHASE_VALUE_2}c1"
+        PAN="${AUDIO_PLAY_MAP}"
     fi
     PLAYBACKFILTER="streams=dv+da[vid][aud],[aud]${PAN},asplit=${AUDIO_SPLIT},\
     ${PHASE_MAP},\


### PR DESCRIPTION
This should make it so what you see/hear for audio and audio scopes during preview and capture maps exactly to what has been selected in the GUI. Should resolve https://github.com/amiaopensource/vrecord/issues/773