### PR TITLE
increase the initial reserved space in the mkv

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1604,7 +1604,7 @@ _lookup_choice(){
         "Matroska")
             EXTENSION="mkv"
             DV_EXTENSION="mkv"
-            MIDDLEOPTIONS+=(-reserve_index_space 1M)
+            MIDDLEOPTIONS+=(-reserve_index_space 10M)
             FORMAT="matroska" ;;
         "AVI")
             EXTENSION="avi"


### PR DESCRIPTION
Increasing to 10MB. In https://github.com/amiaopensource/vrecord/pull/800#issuecomment-2176813095 @iamdamosuzuki found that a 90 minute tape needed 3.5MB just for the Cues, so I think increasing the reservation to 10MB would be a save limit.