### PR TITLE
Allow alternate installs

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -917,6 +917,19 @@ OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
                 <action type="exit">env_reset</action>
             </button>
         </vbox>
+        <vbox>
+            <text>
+                <label>Alternate Dependency Source</label>
+            </text>
+            <entry>
+                <default>"${DEPENDENCYDIR}"</default>
+                <variable>DEPENDENCYDIR</variable>
+            </entry>
+            <button tooltip-text="Select alternate dependency directory and then reset environmental variables">
+                <input file stock="gtk-open"></input>
+                <action type="fileselect">DEPENDENCYDIR</action>
+            </button>
+        </vbox>
     </hbox>
 </frame>
 CONFIG_FORM

--- a/vrecord
+++ b/vrecord
@@ -256,12 +256,12 @@ _gather_ffmpeg_vars(){
         fi
     fi
     if [[ -n "${DEPENDENCYDIR}" ]] ; then
-        ffmpegalt=$(find "${DEPENDENCYDIR}" -iname "ffmpeg-dl" | head -n1)
-            if [[ -n "${ffmpegalt}" ]] ; then
-                FFMPEG_BIN="${ffmpegalt}"
-                FFPLAY_BIN=$(find "${DEPENDENCYDIR}" -iname "ffplay-dl" | head -n1)
-                FFPROBE_BIN=$(find "${DEPENDENCYDIR}" -iname "ffprobe-dl" | head -n1)
-            fi
+        FFMPEGALT=$(find "${DEPENDENCYDIR}" -iname "ffmpeg-dl" | head -n1)
+    fi
+    if [[ -n "${FFMPEGALT}" ]] ; then
+        FFMPEG_BIN="${FFMPEGALT}"
+        FFPLAY_BIN=$(find "${DEPENDENCYDIR}" -iname "ffplay-dl" | head -n1)
+        FFPROBE_BIN=$(find "${DEPENDENCYDIR}" -iname "ffprobe-dl" | head -n1)
     elif which ffmpeg-dl &> /dev/null ; then
         FFMPEG_BIN="$(which ffmpeg-dl)"
         FFPROBE_BIN="$(which ffprobe-dl)"
@@ -921,7 +921,7 @@ OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
             <text>
                 <label>Alternate Dependency Source</label>
             </text>
-            <entry>
+            <entry accept="directory">
                 <default>"${DEPENDENCYDIR}"</default>
                 <variable>DEPENDENCYDIR</variable>
             </entry>
@@ -2290,7 +2290,7 @@ while getopts ":hc:erpaxnvI:O:D:i:G" opt ; do
         v) VERBOSE="true" ;;
         I) EXTRAINPUTOPTIONS=(${OPTARG}) ;;
         O) EXTRAOUTPUTOPTIONS=(${OPTARG}) ;;
-        D) DEPENDENCYDIR=(${OPTARG}) && RUNTYPE="resetenvironment";;
+        D) DEPENDENCYDIR=("${OPTARG}") && RUNTYPE="resetenvironment";;
         i) ALT_INPUT="${OPTARG}" ;;
         G) VERBOSE_GTKDIALOG="Y" ;;
         :) _report -w "Option -${OPTARG} requires an argument" ; _usage ; exit 1 ;;

--- a/vrecord
+++ b/vrecord
@@ -24,7 +24,7 @@ Dependencies: cowsay, amiaopensource/amiaos/decklinksdk,
   xmlstarlet
 Optional Dependencies: deckcontrol, gnuplot, mediaconch, mkvtoolnix, mpv, qcli
 
-Usage: ${SCRIPTNAME} [ -e | -r | -p | -a | -x | -v | -h ] [IDENTIFIER]
+Usage: ${SCRIPTNAME} [ -e | -r | -p | -a | -x | -n|  -v | -h ] [IDENTIFIER]
 
   IDENTIFIER will be used for the filenaming of the output files. It is only
   required in record mode.
@@ -39,6 +39,8 @@ Usage: ${SCRIPTNAME} [ -e | -r | -p | -a | -x | -v | -h ] [IDENTIFIER]
       too long.
   -x  reset the configuration: this will replace the default configuration file
       at '${CONFIG_FILE}' with an empty one.
+  -n  reset Vrecord's stored environment variables. These include
+      variables such as the paths to certain dependencies such as ffmpeg-dl.
   -v  Run ffmpeg with '-loglevel debug'. Using this option creates a very large
       log file, so avoid using this option with 'Visual + Numerical' or any
       playback option that display the log as part of the view.
@@ -53,6 +55,9 @@ Advanced options
       device. For testing without a decklink device.
   -G  Share warnings from gtkdialog and vrecord, otherwise there are suppressed
       by default.
+  -D  Provide a path to a directory containing dependencies to override
+      Vrecord's default dependency paths. These new paths will be stored in
+      Vrecord's environmental variables.
   -c  Provide a recording configuration file, rather than the default one at
       '${CONFIG_FILE}'.
 

--- a/vrecord
+++ b/vrecord
@@ -138,7 +138,7 @@ _process_vars_for_gtk(){
 
     if [[ -z "${OS_TYPE}" ]] ; then
         _setup_env_variables
-        _include_var OS_TYPE RESOURCE_PATH DEFAULTFONT CORE_COUNT OPEN_COMMAND ZCAT_COMMAND COMPUTER_MODEL_NAME DIR_SELECTION_DIALOG
+        _include_var OS_TYPE RESOURCE_PATH DEFAULTFONT CORE_COUNT OPEN_COMMAND ZCAT_COMMAND COMPUTER_MODEL_NAME DIR_SELECTION_DIALOG GTKDIALOGBIN
         if [[ "${OS_TYPE}" = "macOS" ]] ; then
             _include_var COMPUTER_MODEL_ID COMPUTER_PROCESSOR_NAME COMPUTER_PROCESSOR_SPEED COMPUTER_PROCESSOR_COUNT COMPUTER_MEMORY COMPUTER_SERIAL
         fi
@@ -156,7 +156,7 @@ _remove_env_vars(){
     unset VRECORD_VARS_FILE
     unset OS_TYPE RESOURCE_PATH DEFAULTFONT CORE_COUNT OPEN_COMMAND ZCAT_COMMAND COMPUTER_MODEL_NAME DIR_SELECTION_DIALOG
     unset COMPUTER_MODEL_ID COMPUTER_PROCESSOR_NAME COMPUTER_PROCESSOR_SPEED COMPUTER_PROCESSOR_COUNT COMPUTER_MEMORY COMPUTER_SERIAL
-    unset CAPTURELOGSUFFIX TIMECODELOGSUFFIX BREW_PREFIX FFMPEG_BIN FFPLAY_BIN FFPROBE_BIN
+    unset CAPTURELOGSUFFIX TIMECODELOGSUFFIX BREW_PREFIX FFMPEG_BIN FFPLAY_BIN FFPROBE_BIN GTKDIALOGBIN
     VRECORD_VARS_FILE="/tmp/v_$(echo "${0}" | sed -e "s/[^A-Za-z0-9.]/_/g")_variables.txt"
 }
 
@@ -233,6 +233,13 @@ _setup_env_variables(){
         echo "Unsupported OS, ${QUERY_OS_TYPE}, detected. Exiting."
         exit 1
     fi
+    # set gtkdialog path
+    if [[ -n "${DEPENDENCYDIR}" ]] ; then
+        GTKDIALOGBIN=$(find "${DEPENDENCYDIR}" -iname "gtkdialog" | head -n1)
+    fi
+    if [[ -z "${GTKDIALOGBIN}" ]] ; then
+        GTKDIALOGBIN="$(which gtkdialog)"
+    fi
 }
 
 _gather_ffmpeg_vars(){
@@ -248,7 +255,14 @@ _gather_ffmpeg_vars(){
             BREW_PREFIX+=".reinstall"
         fi
     fi
-    if which ffmpeg-dl &> /dev/null ; then
+    if [[ -n "${DEPENDENCYDIR}" ]] ; then
+        ffmpegalt=$(find "${DEPENDENCYDIR}" -iname "ffmpeg-dl" | head -n1)
+            if [[ -n "${ffmpegalt}" ]] ; then
+                FFMPEG_BIN="${ffmpegalt}"
+                FFPLAY_BIN=$(find "${DEPENDENCYDIR}" -iname "ffplay-dl" | head -n1)
+                FFPROBE_BIN=$(find "${DEPENDENCYDIR}" -iname "ffprobe-dl" | head -n1)
+            fi
+    elif which ffmpeg-dl &> /dev/null ; then
         FFMPEG_BIN="$(which ffmpeg-dl)"
         FFPROBE_BIN="$(which ffprobe-dl)"
         FFPLAY_BIN="$(which ffplay-dl)"
@@ -1464,9 +1478,9 @@ _edit_mode(){
     cat "${SHARED_FUNCTIONS_FILE}" >> "${GTK_INC}"
 
     if [[ "${VERBOSE_GTKDIALOG}" = "Y" ]] ; then
-        eval "$(gtkdialog --include="${GTK_INC}" --program MAIN_DIALOG --center)"
+        eval "$("${GTKDIALOGBIN}" --include="${GTK_INC}" --program MAIN_DIALOG --center)"
     else
-        eval "$(gtkdialog --include="${GTK_INC}" --program MAIN_DIALOG --center 2> /dev/null)"
+        eval "$("${GTKDIALOGBIN}" --include="${GTK_INC}" --program MAIN_DIALOG --center 2> /dev/null)"
     fi
     MAIN_DIALOG="${MAIN_DIALOG_TMP}"
 
@@ -2250,7 +2264,7 @@ _review_all_options(){
 
 # command-line options to set media id and original variables
 OPTIND=1
-while getopts ":hc:erpaxnvI:O:i:G" opt ; do
+while getopts ":hc:erpaxnvI:O:D:i:G" opt ; do
     case "${opt}" in
         h) _usage ; exit 0 ;;
         c) CONFIG_FILE="${OPTARG}" ;;
@@ -2263,6 +2277,7 @@ while getopts ":hc:erpaxnvI:O:i:G" opt ; do
         v) VERBOSE="true" ;;
         I) EXTRAINPUTOPTIONS=(${OPTARG}) ;;
         O) EXTRAOUTPUTOPTIONS=(${OPTARG}) ;;
+        D) DEPENDENCYDIR=(${OPTARG}) && RUNTYPE="resetenvironment";;
         i) ALT_INPUT="${OPTARG}" ;;
         G) VERBOSE_GTKDIALOG="Y" ;;
         :) _report -w "Option -${OPTARG} requires an argument" ; _usage ; exit 1 ;;
@@ -2373,7 +2388,11 @@ if [[ "${RUNTYPE}" = "reset" ]] ; then
 fi
 
 if [[ "${RUNTYPE}" = "resetenvironment" ]] ; then
-    _report -q -n "Resetting the configuration will clear ${VRECORD_VARS_FILE}. Please enter [Y] to confirm: "
+    if [[ -n "${DEPENDENCYDIR}" ]] ; then
+        _report -q -n "Rewriting the configuration to include dependencies found in ${DEPENDENCYDIR}. Please enter [Y] to confirm: "
+    else
+        _report -q -n "Resetting the configuration will clear ${VRECORD_VARS_FILE}. Please enter [Y] to confirm: "
+    fi
     read RESET_RESPONSE
     if [[ "${RESET_RESPONSE}" = [Yy] ]] ; then
         _report -d "Clearing ${VRECORD_VARS_FILE}."

--- a/vrecord
+++ b/vrecord
@@ -247,17 +247,18 @@ _gather_ffmpeg_vars(){
             BREW_PREFIX+=".reinstall"
         fi
     fi
-    if [[ -d "${BREW_PREFIX}/bin" ]] ; then
+    if which ffmpeg-dl ; then
+        FFMPEG_BIN="$(which ffmpeg-dl)"
+        FFPROBE_BIN="$(which ffprobe-dl)"
+        FFPLAY_BIN="$(which ffplay-dl)"
+    elif
+        [[ -d "${BREW_PREFIX}/bin" ]] ; then
         FFMPEG_BIN="${BREW_PREFIX}/bin/ffmpeg-dl"
         FFPROBE_BIN="${BREW_PREFIX}/bin/ffprobe-dl"
+        FFPLAY_BIN="${BREW_PREFIX}/bin/ffplay-dl"
     else
         FFMPEG_BIN="$(which ffmpeg)"
         FFPROBE_BIN="$(which ffprobe)"
-    fi
-
-    if "${BREW_PREFIX}/bin/ffplay-dl" -v 0 -f lavfi smptebars=duration=1/25 -autoexit ; then
-        FFPLAY_BIN="${BREW_PREFIX}/bin/ffplay-dl"
-    else
         FFPLAY_BIN="$(which ffplay)"
     fi
 }

--- a/vrecord
+++ b/vrecord
@@ -157,6 +157,7 @@ _remove_env_vars(){
     unset OS_TYPE RESOURCE_PATH DEFAULTFONT CORE_COUNT OPEN_COMMAND ZCAT_COMMAND COMPUTER_MODEL_NAME DIR_SELECTION_DIALOG
     unset COMPUTER_MODEL_ID COMPUTER_PROCESSOR_NAME COMPUTER_PROCESSOR_SPEED COMPUTER_PROCESSOR_COUNT COMPUTER_MEMORY COMPUTER_SERIAL
     unset CAPTURELOGSUFFIX TIMECODELOGSUFFIX BREW_PREFIX FFMPEG_BIN FFPLAY_BIN FFPROBE_BIN
+    VRECORD_VARS_FILE="/tmp/v_$(echo "${0}" | sed -e "s/[^A-Za-z0-9.]/_/g")_variables.txt"
 }
 
 _setup_env_variables(){
@@ -247,7 +248,7 @@ _gather_ffmpeg_vars(){
             BREW_PREFIX+=".reinstall"
         fi
     fi
-    if which ffmpeg-dl ; then
+    if which ffmpeg-dl &> /dev/null ; then
         FFMPEG_BIN="$(which ffmpeg-dl)"
         FFPROBE_BIN="$(which ffprobe-dl)"
         FFPLAY_BIN="$(which ffplay-dl)"
@@ -2249,7 +2250,7 @@ _review_all_options(){
 
 # command-line options to set media id and original variables
 OPTIND=1
-while getopts ":hc:erpaxvI:O:i:G" opt ; do
+while getopts ":hc:erpaxnvI:O:i:G" opt ; do
     case "${opt}" in
         h) _usage ; exit 0 ;;
         c) CONFIG_FILE="${OPTARG}" ;;
@@ -2258,6 +2259,7 @@ while getopts ":hc:erpaxvI:O:i:G" opt ; do
         p) RUNTYPE="passthrough" ;;
         a) RUNTYPE="audiopassthrough" ;;
         x) RUNTYPE="reset" ;;
+        n) RUNTYPE="resetenvironment" ;;
         v) VERBOSE="true" ;;
         I) EXTRAINPUTOPTIONS=(${OPTARG}) ;;
         O) EXTRAOUTPUTOPTIONS=(${OPTARG}) ;;
@@ -2369,6 +2371,22 @@ if [[ "${RUNTYPE}" = "reset" ]] ; then
         exit 0
     fi
 fi
+
+if [[ "${RUNTYPE}" = "resetenvironment" ]] ; then
+    _report -q -n "Resetting the configuration will clear ${VRECORD_VARS_FILE}. Please enter [Y] to confirm: "
+    read RESET_RESPONSE
+    if [[ "${RESET_RESPONSE}" = [Yy] ]] ; then
+        _report -d "Clearing ${VRECORD_VARS_FILE}."
+        _remove_env_vars
+        _process_vars_for_gtk
+        RUNTYPE="edit"
+        STARTUP_VIEW="INPUTSETTINGS"
+    else
+        _report -d "Reset aborted. Exiting."
+        exit 0
+    fi
+fi
+
 while [[ "${RUNTYPE}" = "edit" ]] ; do
     STARTUP_VIEW="INPUTSETTINGS"
     _edit_mode

--- a/vrecord.1
+++ b/vrecord.1
@@ -1,4 +1,4 @@
-.TH vrecord 1 "https://github.com/amiaopensource/vrecord" "2024-01-26" "AMIA Open Source"
+.TH vrecord 1 "https://github.com/amiaopensource/vrecord" "2024-07-18" "AMIA Open Source"
 .\" Turn off justification for nroff.
 .if n .ad l
 .\" Turn off hyphenation.
@@ -6,7 +6,7 @@
 .SH NAME
 vrecord - An Open-Source Video Capture Tool for Archivists
 .SH SYNOPSIS
-\fBvrecord\fR [\fB-e\fR | \fB-r \fIidentifier\fR | \fB-p\fR | \fB-a\fR | \fB-x\fR | \fB-v\fR | \fB-h\fR]
+\fBvrecord\fR [\fB-e\fR | \fB-r \fIidentifier\fR | \fB-p\fR | \fB-a\fR | \fB-x\fR | \fB-n\fR | \fB-v\fR | \fB-h\fR]
 .SH DESCRIPTION
 Vrecord is open-source software for capturing a video signal and turning it into a digital file. Its purpose is to make videotape digitization or transfer easier. Vrecord can capture analog and digital signals through a variety of inputs and can create digital video files in a variety of formats and codecs. Vrecord has been designed with needs of audiovisual archivists in mind.
 .PP
@@ -28,6 +28,9 @@ Running vrecord in \fBEdit Mode\fR opens a GUI window that allows you to change 
 .B -x
 \fBClear Configuration:\fR Use if you would like to clear all options set in the configuration file.
 .TP
+.B -n
+\fBReset environmental variables:\fR Use if you would like to reset stored environmental variables such as path to ffmpeg-dl dependency.
+.TP
 .B -v
 In the \fBVerbose Mode\fR ffmpeg runs with '-loglevel debug'. Using this option creates a very large log file, so avoid using this option with 'Visual + Numerical' or any playback option that display the log as part of the view.
 .TP
@@ -40,6 +43,9 @@ Provide a string of input options for the recording ffmpeg to use. For example "
 .TP
 .B -O
 Provide a string of output options for the recording ffmpeg to use.
+.TP
+.B -D
+Provide a directory containing vrecord dependencies to store their paths in vrecord's environmental variables instead of defaults.
 .TP
 .B -i
 Provide a file as an input to vrecord, rather than using the decklink device. For testing without a decklink device.


### PR DESCRIPTION
* Adds option to clear environmental variables from CLI
* Fixes bug of cleared variables not displaying after reset
* Adds option in CLI and GUI to set an alternate directory source for some dependencies to support custom and non brew installations (Currently this can be used to set ffmpeg tools and gtkdialog, but could be expanded)