### PR TITLE
mapping for mono playback

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1826,17 +1826,21 @@ _lookup_choice(){
             AUDIO_CHANNEL_MAP+=(-map "[stereo1]") ;;
         "Channel 1 -> 1st Track Mono, Channel 2 -> 2nd Track Mono")
             AUDIOMAP="[0:a:0]pan=mono| c0=c0[mono1];[0:a:0]pan=mono| c0=${PHASE_VALUE_2}c1[mono2]"
+            AUDIO_PLAY_MAP="pan=stereo|c0=c0|c1=${PHASE_VALUE_2}c1"
             AUDIO_CHANNEL_MAP+=(-map "[mono1]")
             AUDIO_CHANNEL_MAP+=(-map "[mono2]") ;;
         "Channel 2 -> 1st Track Mono, Channel 1 -> 2nd Track Mono")
             AUDIOMAP="[0:a:0]pan=mono| c0=${PHASE_VALUE_2}c1[mono1];[0:a:0]pan=mono| c0=c0[mono2]"
+            AUDIO_PLAY_MAP="pan=stereo|c0=${PHASE_VALUE_2}c1|c1=c0"
             AUDIO_CHANNEL_MAP+=(-map "[mono1]")
             AUDIO_CHANNEL_MAP+=(-map "[mono2]") ;;
         "Channel 1 -> Single Track Mono")
             AUDIOMAP="[0:a:0]pan=mono| c0=c0[mono1]"
+            AUDIO_PLAY_MAP="pan=mono| c0=c0"
             AUDIO_CHANNEL_MAP+=(-map "[mono1]") ;;
         "Channel 2 -> Single Track Mono")
             AUDIOMAP="[0:a:0]pan=mono| c0=c1[mono1]"
+            AUDIO_PLAY_MAP="pan=mono| c0=c1"
             AUDIO_CHANNEL_MAP+=(-map "[mono1]") ;;
         # Audio mode channel options
         "Mono")


### PR DESCRIPTION
Making this PR for testing. This should make all the mono options 'what you hear is what you get' in terms of channel mapping in monitoring and file output.

Let me know if people have a chance to test/have any thoughts about this! This will make it harder for people to accidentally have vrecord set to capture the wrong channel for mono, but also potentially would allow people to miss realizing a second track exists when vrecord is set to capture a single mono track, as the second track will no longer appear in the meters.

The only way I can see to avoid this is to have two sets of audio meters, one that displays volume for all tracks and one that displays volume for mapped tracks...but that probably is then making the views overcrowded.