### PR TITLE
Mp4 updates

### DIFF
--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -88,7 +88,6 @@ _update_config_file(){
         echo "DV_RESCUE_OPTION_T=\"${DV_RESCUE_OPTION_T}\""
         echo "DV_RESCUE_OPTION_TC=\"${DV_RESCUE_OPTION_TC}\""
         echo "MP4_CRF_VALUE=\"${MP4_CRF_VALUE}\""
-        echo "MP4_EXTRA_OPTS=\"${MP4_EXTRA_OPTS}\""
         echo "CC2VTT=\"${CC2VTT}\""
         echo "CC2SRT=\"${CC2SRT}\""
     } > "${CONFIG_FILE}"

--- a/vrecord
+++ b/vrecord
@@ -2545,6 +2545,7 @@ if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
         if [[ -z "${MP4_CRF_VALUE}" ]] ; then
             MP4_CRF_VALUE="21"
         fi
+        RECORDINGFILTER_MP4+=",bwdif"
         RECORD_COMMAND_MP4+=(-filter_complex "[0:v:0]${RECORDINGFILTER_MP4#,*}[mp4_v_out];${AUDIOMAP}")
         MP4NAME="${DIR}/${FULL_OUTPUT_ID}.mp4"
         EXTRAOUTPUTS+=("${MIDDLEOPTIONS_ALL[@]}" -movflags write_colr+faststart -crf "${MP4_CRF_VALUE}" "${RECORD_COMMAND_MP4[@]}" ${MP4_EXTRA_OPTS} -pix_fmt yuv420p -c:v libx264 -c:a aac -map "[mp4_v_out]" "${AUDIO_CHANNEL_MAP[@]}" "${MP4NAME}")

--- a/vrecord
+++ b/vrecord
@@ -1882,6 +1882,7 @@ _lookup_choice(){
                 RECORDINGFILTER+=",crop=w=720:h=480:x=0:y=4,"
                 MIDDLEOPTIONS_PRES+=(-x264opts bff)
             fi
+            RECORDINGFILTER_MP4+=",crop=w=720:h=480:x=0:y=4"
             RECORDINGFILTER+=",setparams=field_mode=${SIGNAL_INT_CHOICE:-auto}"
             MIDDLEOPTIONS_ALL+=(-color_primaries smpte170m)
             MIDDLEOPTIONS_ALL+=(-color_trc bt709)
@@ -1901,16 +1902,20 @@ _lookup_choice(){
         "4/3")
             if [[ "${STANDARD}" = "ntsc" ]] ; then
                 RECORDINGFILTER+=",setsar=${NTSC_43_SAR_CHOICE}"
+                RECORDINGFILTER_MP4+=",setsar=${NTSC_43_SAR_CHOICE}"
             elif [[ "${STANDARD}" = "pal " ]] ; then
                 RECORDINGFILTER+=",setsar=${PAL_43_SAR_CHOICE}"
+                RECORDINGFILTER_MP4+=",setsar=${PAL_43_SAR_CHOICE}"
             else
                 _report -w "Error: the standard wasn't set to an expected when it was expected to be."
             fi ;;
         "16/9")
             if [[ "${STANDARD}" = "ntsc" ]] ; then
                 RECORDINGFILTER+=",setsar=${PAL_43_SAR_CHOICE}"
+                RECORDINGFILTER_MP4+=",setsar=${PAL_43_SAR_CHOICE}"
             elif [[ "${STANDARD}" = "pal " ]] ; then
                 RECORDINGFILTER+=",setsar=${PAL_169_SAR_CHOICE}"
+                RECORDINGFILTER_MP4+=",setsar=${PAL_169_SAR_CHOICE}"
             else
                 _report -w "Error: the standard wasn't set to an expected when it was expected to be."
             fi ;;
@@ -2540,8 +2545,9 @@ if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
         if [[ -z "${MP4_CRF_VALUE}" ]] ; then
             MP4_CRF_VALUE="21"
         fi
+        RECORD_COMMAND_MP4+=(-filter_complex "[0:v:0]${RECORDINGFILTER_MP4#,*}[mp4_v_out];${AUDIOMAP}")
         MP4NAME="${DIR}/${FULL_OUTPUT_ID}.mp4"
-        EXTRAOUTPUTS+=("${MIDDLEOPTIONS_ALL[@]}" -movflags write_colr+faststart -crf "${MP4_CRF_VALUE}" ${MP4_EXTRA_OPTS} -pix_fmt yuv420p -c:v libx264 -filter_complex "${AUDIOMAP}" -c:a aac "${AUDIO_CHANNEL_MAP[@]}" -map 0:v "${MP4NAME}")
+        EXTRAOUTPUTS+=("${MIDDLEOPTIONS_ALL[@]}" -movflags write_colr+faststart -crf "${MP4_CRF_VALUE}" "${RECORD_COMMAND_MP4[@]}" ${MP4_EXTRA_OPTS} -pix_fmt yuv420p -c:v libx264 -c:a aac -map "[mp4_v_out]" "${AUDIO_CHANNEL_MAP[@]}" "${MP4NAME}")
     fi
     if [[ "${FORMAT}" = "matroska" ]] ; then
         _review_option "EMBED_LOGS_CHOICE" "${EMBED_LOGS_OPTIONS[@]}"

--- a/vrecord
+++ b/vrecord
@@ -789,13 +789,6 @@ OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
                     <default>"${MP4_CRF_VALUE}"</default>
                     <variable>MP4_CRF_VALUE</variable>
                 </entry>
-                <text>
-                    <label>Custom output options. You can add custom optons such as '-vf yadif' here. Use cautiously and note that '-movflags write_colr+faststart -pix_fmt yuv420p -c:v libx264 -c:a aac' is already set.</label>
-                </text>
-                <entry activates_default="true">
-                    <default>"${MP4_EXTRA_OPTS}"</default>
-                    <variable>MP4_EXTRA_OPTS</variable>
-                </entry>
             </frame>
             <frame Player AspectRatioSettings>
                 <vbox>
@@ -2548,7 +2541,7 @@ if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
         RECORDINGFILTER_MP4+=",bwdif"
         RECORD_COMMAND_MP4+=(-filter_complex "[0:v:0]${RECORDINGFILTER_MP4#,*}[mp4_v_out];${AUDIOMAP}")
         MP4NAME="${DIR}/${FULL_OUTPUT_ID}.mp4"
-        EXTRAOUTPUTS+=("${MIDDLEOPTIONS_ALL[@]}" -movflags write_colr+faststart -crf "${MP4_CRF_VALUE}" "${RECORD_COMMAND_MP4[@]}" ${MP4_EXTRA_OPTS} -pix_fmt yuv420p -c:v libx264 -c:a aac -map "[mp4_v_out]" "${AUDIO_CHANNEL_MAP[@]}" "${MP4NAME}")
+        EXTRAOUTPUTS+=("${MIDDLEOPTIONS_ALL[@]}" -movflags write_colr+faststart -crf "${MP4_CRF_VALUE}" "${RECORD_COMMAND_MP4[@]}" -pix_fmt yuv420p -c:v libx264 -c:a aac -map "[mp4_v_out]" "${AUDIO_CHANNEL_MAP[@]}" "${MP4NAME}")
     fi
     if [[ "${FORMAT}" = "matroska" ]] ; then
         _review_option "EMBED_LOGS_CHOICE" "${EMBED_LOGS_OPTIONS[@]}"

--- a/vrecord
+++ b/vrecord
@@ -580,7 +580,7 @@ _setup_vrecord_process(){
         fi
         RECORD_COMMAND+=("${MIDDLEOPTIONS_PRES[@]}" "${MIDDLEOPTIONS_ALL[@]}")
         if [[ "${RUNTYPE}" = "record" ]] ; then
-            RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER}${TC_WRITE}${CAPTION_WRITE};${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
+            RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER#,*}${TC_WRITE}${CAPTION_WRITE};${AUDIOMAP}" "${AUDIO_CHANNEL_MAP[@]}")
             RECORD_COMMAND+=(-f "${FORMAT}" "${VRECORD_OUTPUT}")
             RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}")
         fi
@@ -1879,10 +1879,10 @@ _lookup_choice(){
             STANDARD="ntsc"
             DECKLINK_FPS="30000/1001"
             if [[ "${VIDEO_CODEC_CHOICE}" = "h264" ]] ; then
-                RECORDINGFILTER+="crop=w=720:h=480:x=0:y=4,"
+                RECORDINGFILTER+=",crop=w=720:h=480:x=0:y=4,"
                 MIDDLEOPTIONS_PRES+=(-x264opts bff)
             fi
-            RECORDINGFILTER+="setparams=field_mode=${SIGNAL_INT_CHOICE:-auto}"
+            RECORDINGFILTER+=",setparams=field_mode=${SIGNAL_INT_CHOICE:-auto}"
             MIDDLEOPTIONS_ALL+=(-color_primaries smpte170m)
             MIDDLEOPTIONS_ALL+=(-color_trc bt709)
             MIDDLEOPTIONS_ALL+=(-colorspace smpte170m) ;;
@@ -1892,7 +1892,7 @@ _lookup_choice(){
             if [[ "${VIDEO_CODEC_CHOICE}" = "h264" ]] ; then
                 MIDDLEOPTIONS_PRES+=(-x264opts tff)
             fi
-            RECORDINGFILTER+="setparams=field_mode=${SIGNAL_INT_CHOICE:-auto}"
+            RECORDINGFILTER+=",setparams=field_mode=${SIGNAL_INT_CHOICE:-auto}"
             MIDDLEOPTIONS_ALL+=(-color_primaries bt470bg)
             MIDDLEOPTIONS_ALL+=(-color_trc bt709)
             MIDDLEOPTIONS_ALL+=(-colorspace bt470bg) ;;


### PR DESCRIPTION
this PR drops the customized arguments for the mp4 sidecar output in an effort to standardized that output rather than putting it on the user to figure it out. This responds to the comment at https://github.com/amiaopensource/vrecord/issues/857#issuecomment-2515637292. I think putting it on the user to add their own setsar is an overburden.

This copies a few of the recording filters to the mp4 output: a 720x486 to 720x480 crop if NTSC, a copy of the sar used for the preservation output, and adds bwdif for a progressive deinterlaced output.