### PR TITLE
added 200 minute recording limit for qctools generation

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -562,7 +562,7 @@ _setup_vrecord_process(){
                 VRECORD_STEPS="1" # Steps: player
             fi
         fi
-        
+
         # caption handling if ntsc
         if [[ "${STANDARD}" == "ntsc" ]] ; then
             CAPTION_TMP="$(_maketemp .eia608.txt)"
@@ -2700,6 +2700,11 @@ if [[ -n "${DURATION}" ]] ; then
     DUR_SECONDS=$(bc <<< "${DURATION} * 60" | sed "s/^\./0./")
     TIME_LIMIT=(-t "${DUR_SECONDS}")
     DURATION_TEXT="Tape duration set to: ${DURATION} minutes."
+fi
+
+if [[ "${DURATION}" -gt 200 ]] ; then
+    _report -w "WARNING: Recording duration set to greater than 200 minutes. QCTools report will not be generated."
+    QCTOOLSXML_CHOICE="No"
 fi
 
 if [[ -n ${TECHNICIAN} ]] ; then


### PR DESCRIPTION
if recording duration is set to above 200 minutes, qctools generation will be turned off

meant to address: https://github.com/amiaopensource/vrecord/issues/887