### PR TITLE
Redo output strategy

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -568,7 +568,7 @@ _setup_vrecord_process(){
         RECORD_COMMAND+=("${MIDDLEOPTIONS_PRES[@]}" "${MIDDLEOPTIONS_ALL[@]}")
         if [[ "${RUNTYPE}" = "record" ]] ; then
             RECORD_COMMAND+=(-filter_complex "[0:v:0]${RECORDINGFILTER#,*}${TC_WRITE}${CAPTION_WRITE}[vout];${AUDIOMAP}" -map "[vout]" "${AUDIO_CHANNEL_MAP[@]}")
-            RECORD_COMMAND+=(-f tee [f=${FORMAT}:select=v,${AUDIO_TEE_SELECT_MAP}]${VRECORD_OUTPUT}\|[f=nut:onfail=abort:select=v,a\\\\:0,${AUDIO_TEE_SELECT_MAP}]pipe:1)
+            RECORD_COMMAND+=(-f tee [f=${FORMAT}:select=v,${AUDIO_TEE_SELECT_MAP}]${VRECORD_OUTPUT}\|[f=nut:onfail=abort:select=v,${AUDIO_TEE_SELECT_MAP},a\\\\:0]pipe:1)
             RECORD_COMMAND+=("${EXTRAOUTPUTS[@]}")
         else
             if [[ "${SIGNAL_INPUT}" = 'true' ]] ; then
@@ -2788,8 +2788,8 @@ read
 INGESTLOG="${LOGDIR}/${FULL_OUTPUT_ID}_capture_options.log"
 QCTOOLS_REPORT="${LOGDIR}/${FULL_OUTPUT_ID}.${EXTENSION}.qctools.mkv"
 QCXML="$(_maketemp)"
-QCLI_COMMAND_PIPE=(qcli -audio all -f signalstats+aphasemeter+astats+ssim -i - -o "${QCTOOLS_REPORT}")
-QCLI_COMMAND_FILE=(qcli -audio all -f signalstats+aphasemeter+astats+ssim -i "${VRECORD_OUTPUT}" -o "${QCTOOLS_REPORT}")
+QCLI_COMMAND_PIPE=(qcli -audio 1 -f signalstats+aphasemeter+astats+ssim -i - -o "${QCTOOLS_REPORT}")
+QCLI_COMMAND_FILE=(qcli -audio 1 -f signalstats+aphasemeter+astats+ssim -i "${VRECORD_OUTPUT}" -o "${QCTOOLS_REPORT}")
 touch "${INGESTLOG}"
 _writeingestlog "computer_name" "$(uname -n)"
 _writeingestlog "computer_model_name" "${COMPUTER_MODEL_NAME}"


### PR DESCRIPTION
this refactors the output to use the tee muxer (which has the recording output and also the output to the player). With the tee muxer, we can specify how any output stops based on the end of another output, so that helps us get off ffmpeg@5 to ffmpeg@7.

The output now looks like (example here for two stereo tracks in the output): ` -f tee [f=matroska:select=v,a\\:1,a\\:2]WHATUP.mkv|[f=nut:onfail=abort:select=v,a\\:0,a\\:1,a\\:2]pipe:1`. These stream mappings refer to output streams rather than input ones. Elsewhere the first output audio is always a copy of the input (8 channels for the decklink) and then the others are the recording output audio streams, so the recording output gets `v,a\\:1,a\\:2` and the output to the player gets `v,a\\:0,a\\:1,a\\:2`. Next to do is to update the player to show the input vs output audio.