### PR TITLE
remove mp4 options tab title

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1541,6 +1541,7 @@ _edit_mode(){
         done
         echo "--------------|---------------"
         RUNTYPE="edit"
+        unset MIDDLEOPTIONS_ALL MIDDLEOPTIONS_PRES RECORDINGFILTER AUDIO_CHANNEL_MAP
     elif [[ "${EXIT}" = "env_reset" ]] ; then
         _remove_env_vars
         _process_vars_for_gtk

--- a/vrecord
+++ b/vrecord
@@ -1614,8 +1614,7 @@ _qcgraphimage(){
        -v "tag[@key='lavfi.ssim.V']/@value" -n > "${qctools_CONFIGFILE_V}"
 
     # determine SATURATION scale
-    VBitdepth="$("${ZCAT_COMMAND}" "$1" | perl -nle 'print if not m{<frame|</frame|<tag}' | xmlstarlet sel -t -v "//stream[@codec_type='video']/@pix_fmt" -n
-    )"
+    VBitdepth="$("${ZCAT_COMMAND}" "$1" | perl -nle 'print if not m{<frame |</frame>|<tag}' | xmlstarlet sel -t -v "//stream[@codec_type='video']/@pix_fmt" -n)"
     if [[ "${VBitdepth}" = "yuv422p10le" ]] ; then
         SATpalette="(0'#a0a0a0',80'#bebebe',177.4'#c8c800',322'#a0ff20',354.8'#00ff00',413.8'#006400',433.46'#00ff00',453.13'#a0ff20',472.8'#ffa500',496'#ff0000')"
         SATcbrange="[0:496]"

--- a/vrecord
+++ b/vrecord
@@ -781,7 +781,7 @@ PLAYBACK_OPT_GUI="
 OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
 <frame Preferences>
     <hbox>
-        <notebook tab-labels="Player|MP4 Sidecar|Aspect Ratio|Closed Captioning">
+        <notebook tab-labels="Player|Aspect Ratio|Closed Captioning">
             <frame Player Settings>
                 <hbox>
                 $(_gtk_vbox_list "WAVEFORM_SCALE_CHOICE" "100" "Select Waveform Scale"            "${WAVEFORM_SCALE_OPTIONS[@]}")

--- a/vrecord
+++ b/vrecord
@@ -2460,7 +2460,10 @@ AUDIO_CODEC_PCM_TEST='
 
 AUDIO_CODEC_FLAC_TEST='
     <rule name="Is the audio FLAC?" value="Format" tracktype="Audio" operator="=">FLAC</rule>
-    <rule name="Is the audio bit depth 32?" value="BitDepth" tracktype="Audio" operator="=">32</rule>
+    <policy type="or" name="Bit Depth is 32 or 24?">
+        <rule name="Bit Depth is 32?" value="BitDepth" tracktype="Audio" operator="=">32</rule>
+        <rule name="Bit Depth is 24?" value="BitDepth" tracktype="Audio" operator="=">24</rule>
+    </policy>
 '
 # define mediaconch test fragment -end
 

--- a/vrecord
+++ b/vrecord
@@ -2460,7 +2460,7 @@ AUDIO_CODEC_PCM_TEST='
 
 AUDIO_CODEC_FLAC_TEST='
     <rule name="Is the audio FLAC?" value="Format" tracktype="Audio" operator="=">FLAC</rule>
-    <rule name="Is the audio bit depth 24?" value="BitDepth" tracktype="Audio" operator="=">24</rule>
+    <rule name="Is the audio bit depth 32?" value="BitDepth" tracktype="Audio" operator="=">32</rule>
 '
 # define mediaconch test fragment -end
 


### PR DESCRIPTION
Fixes a bug where config window doesn't render correctly because we removed the MP4 options in https://github.com/amiaopensource/vrecord/pull/911/ but forgot to remove the MP4 Sidecar tab's title from the preferences window.