### PR TITLE
[WIP] this adds a live display to the caption viewer

### DIFF
--- a/cchex_to_display
+++ b/cchex_to_display
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# cc_to_srt_safe.sh
+# Convert EIA-608 hex dump to readable text (simplified version)
+bash --version
+INPUT_FILE="$1"
+OUTPUT_FILE="$2"
+OUTPUT_FILE_TMP="${OUTPUT_FILE}.tmp"
+
+if [[ -z "$INPUT_FILE" || -z "$OUTPUT_FILE" ]]; then
+    echo "Usage: $0 <input_file> <output_file>"
+    exit 1
+fi
+
+declare -A char_map=(
+    ["20"]=" "
+    ["A1"]="!"
+    ["A2"]="\""
+    ["23"]="#"
+    ["A4"]="$"
+    ["25"]="%"
+    ["26"]="&"
+    ["A7"]="'"
+    ["A8"]="("
+    ["29"]=")"
+    ["2A"]="á"
+    ["AB"]="+"
+    ["2C"]=","
+    ["AD"]="-"
+    ["AE"]="."
+    ["2F"]="/"
+    ["B0"]="0"
+    ["31"]="1"
+    ["32"]="2"
+    ["B3"]="3"
+    ["34"]="4"
+    ["B5"]="5"
+    ["B6"]="6"
+    ["37"]="7"
+    ["38"]="8"
+    ["B9"]="9"
+    ["BA"]=":"
+    ["3B"]=";"
+    ["BC"]="<"
+    ["3D"]="="
+    ["3E"]=">"
+    ["BF"]="?"
+    ["40"]="@"
+    ["C1"]="A"
+    ["C2"]="B"
+    ["43"]="C"
+    ["C4"]="D"
+    ["45"]="E"
+    ["46"]="F"
+    ["C7"]="G"
+    ["C8"]="H"
+    ["49"]="I"
+    ["4A"]="J"
+    ["CB"]="K"
+    ["4C"]="L"
+    ["CD"]="M"
+    ["CE"]="N"
+    ["4F"]="O"
+    ["D0"]="P"
+    ["51"]="Q"
+    ["52"]="R"
+    ["D3"]="S"
+    ["54"]="T"
+    ["D5"]="U"
+    ["D6"]="V"
+    ["57"]="W"
+    ["58"]="X"
+    ["D9"]="Y"
+    ["DA"]="Z"
+    ["5B"]="["
+    ["DC"]="é"
+    ["5D"]="]"
+    ["5E"]="í"
+    ["DF"]="ó"
+    ["E0"]="ú"
+    ["61"]="a"
+    ["62"]="b"
+    ["E3"]="c"
+    ["64"]="d"
+    ["E5"]="e"
+    ["E6"]="f"
+    ["67"]="g"
+    ["68"]="h"
+    ["E9"]="i"
+    ["EA"]="j"
+    ["6B"]="k"
+    ["EC"]="l"
+    ["6D"]="m"
+    ["6E"]="n"
+    ["EF"]="o"
+    ["70"]="p"
+    ["F1"]="q"
+    ["F2"]="r"
+    ["73"]="s"
+    ["F4"]="t"
+    ["75"]="u"
+    ["76"]="v"
+    ["F7"]="w"
+    ["F8"]="x"
+    ["79"]="y"
+    ["7A"]="z"
+    ["FB"]="ç"
+    ["7C"]="÷"
+    ["FD"]="Ñ"
+    ["FE"]="ñ"
+    ["7F"]=" "
+)
+
+# --- Fast lookup ---
+lookup() {
+    local key="$1"
+    echo -n "${char_map[$key]}"
+}
+
+unset START_FRAME
+# --- Start buffer to hold last 30 chars ---
+TAIL_SCAN="60"
+CAPTION_LINE_LENGTH="64"
+BUFFER="$(printf "%*s" "${CAPTION_LINE_LENGTH}" "")"
+if [[ ! -f "${OUTPUT_FILE}" ]] ; then
+    echo -n "${BUFFER}" > "${OUTPUT_FILE_TMP}"
+    mv "${OUTPUT_FILE_TMP}" "${OUTPUT_FILE}"
+fi
+while true ; do
+    LAST_METADATA="$(tail -n "${TAIL_SCAN}" "${INPUT_FILE}")"
+    if [[ -z "$START_FRAME" ]] ; then
+        METADATA_TO_PROCESS="${LAST_METADATA}"
+    else
+        METADATA_TO_PROCESS="$(echo "${LAST_METADATA}" | grep -A "${TAIL_SCAN}" "frame:${START_FRAME} ")"
+    fi
+    START_FRAME="$(echo "${LAST_METADATA}" | grep -o 'frame:[0-9]*' | tail -n1 | cut -d: -f2)"
+    NEW_CCS="$(echo "${METADATA_TO_PROCESS}" | grep "lavfi.readeia608.0.cc=" | cut -d "=" -f2)"
+    ((START_FRAME++))
+    while IFS= read -r CC_HEX ; do
+        CC_HEX="${CC_HEX//0x}"
+        if [[ "${CC_HEX}" != "8080" && -n "${CC_HEX}" ]] ; then
+            CC1="$(lookup "${CC_HEX:0:2}")"
+        else
+            unset CC1
+        fi
+        if [[ -n "${CC1}" ]] ; then
+            CC2="$(lookup "${CC_HEX:2:2}")"
+            BUFFER+="${CC1}${CC2}"
+            BUFFER="${BUFFER: -${CAPTION_LINE_LENGTH}}"
+            echo -n "${BUFFER}" > "${OUTPUT_FILE_TMP}"
+            mv "${OUTPUT_FILE_TMP}" "${OUTPUT_FILE}"
+        else
+            BUFFER+=" "
+            if [[ -z "${BUFFER: -${CAPTION_LINE_LENGTH}}" ]] ; then
+                BUFFER="$(printf "%*s" "${CAPTION_LINE_LENGTH}" "")"
+            else
+                BUFFER="${BUFFER: -${CAPTION_LINE_LENGTH}}"
+                if [[ -n "${BUFFER// }" || "${CLEAR}" == "1" ]] ; then
+                    echo -n "${BUFFER}" > "${OUTPUT_FILE_TMP}"
+                    mv "${OUTPUT_FILE_TMP}" "${OUTPUT_FILE}"
+                    CLEAR="0"
+                else
+                    CLEAR="1"
+                fi
+            fi
+        fi
+        echo "BUFFER=(${BUFFER}) CC1=${CC1} CC2=${CC2}"
+        unset CC1 CC2
+    done <<< "${NEW_CCS}"
+    sleep 0.2
+done

--- a/vrecord
+++ b/vrecord
@@ -479,7 +479,6 @@ _setup_vrecord_input(){
     if [[ -n "${ALT_INPUT}" ]] ; then
         _set_ffmpeg_loglevel
         GRAB_INPUT+=(-i "${ALT_INPUT}")
-        GRAB_INPUT+=(-dn)
     elif [[ "${SIGNAL_INPUT}" = 'true' ]] ; then
         TEST_SIGNAL_CHOICE="testsrc=size=${SIG_GEN_SIZE}:r=${DECKLINK_FPS}"
         VIDEO_INPUT="Test signal: ${TEST_SIGNAL_CHOICE}"
@@ -1561,11 +1560,14 @@ _passthrough_mode(){
         echo "RECORD ${RECORD_COMMAND[@]}"
     fi
 
+    "${SCRIPTDIR}/cchex_to_display" "${FFREPORT_TMP}" "${CAP_DISPLAY_TMP}" > /dev/null 2> /dev/null &
+    CC_PID=$!
     if [[ "${VRECORD_STEPS}" = "1" ]] ; then
-        "${PLAYER_COMMAND[@]}" 2> "${VRECORD_INPUT_TMP}"
+        export FFREPORT="file=${FFREPORT_TMP}:level=32" ; "${PLAYER_COMMAND[@]}" 2> "${VRECORD_INPUT_TMP}"
     elif [[ "${VRECORD_STEPS}" = "2" ]] ; then
-        "${RECORD_COMMAND[@]}" 2> "${VRECORD_INPUT_TMP}" | "${PLAYER_COMMAND[@]}"
+        export FFREPORT="file=${FFREPORT_TMP}:level=32" ; "${RECORD_COMMAND[@]}" 2> "${VRECORD_INPUT_TMP}" | "${PLAYER_COMMAND[@]}"
     fi
+    kill "$CC_PID"
 }
 
 _audiopassthrough_mode(){
@@ -2147,7 +2149,7 @@ color=color=darkgray,scale=${CORNER_W}*${CORNER_ZOOM}*2:${CORNER_H}*2,split=4[l1
         "Captions")
             PLAYBACKFILTER="\
 ${PLAYBACK_FILTER_ADJUSTMENT}format=yuv420p10le|yuv422p10le|yuv444p10le|yuv440p10le,split=4[f1][f2][f3][f4];\
-            [f1]readeia608=scan_max=2:spw=0.30,drawtext=fontfile=${DEFAULTFONT}:fontcolor=white:fontsize=36:box=1:boxcolor=black@0.5:x=(w-tw)/2:y=h*3/4-ascent:text=Line %{metadata\\\:lavfi.readeia608.0.line\\\:-} %{metadata\\\:lavfi.readeia608.0.cc\\\:------} - Line %{metadata\\\:lavfi.readeia608.1.line\\\:-} %{metadata\\\:lavfi.readeia608.1.cc\\\:------}[f1b];\
+            [f1]readeia608=scan_max=2:spw=0.30,metadata=mode=print:key=lavfi.readeia608.0.cc,drawtext=fontfile=${DEFAULTFONT}:fontcolor=white:fontsize=36:box=1:boxcolor=black@0.5:x=(w-tw)/2:y=h*3/4-ascent:text=Line %{metadata\\\:lavfi.readeia608.0.line\\\:-} %{metadata\\\:lavfi.readeia608.0.cc\\\:------} - Line %{metadata\\\:lavfi.readeia608.1.line\\\:-} %{metadata\\\:lavfi.readeia608.1.cc\\\:------},drawtext=fontfile=${DEFAULTFONT}:textfile=${CAP_DISPLAY_TMP}:reload=1:fontcolor=white:fontsize=18:x=(w-text_w)/2:y=h-100:shadowcolor=blue:shadowx=1:shadowy=1[f1b];\
             [f2]crop=iw:1:0:1,scale=iw:2:flags=neighbor,tile=layout=1x120:overlap=119:init_padding=119[caption_scroll];\
             [f3]format=gray,crop=iw:1:0:1,waveform=i=1:g=green,drawtext=fontfile=${DEFAULTFONT}:text='Line 1':fontcolor=white:fontsize=18:x=20:y=20[wvf];\
             [f4]format=gray,crop=iw:1:0:2,waveform=i=1:g=green,drawtext=fontfile=${DEFAULTFONT}:text='Line 2':fontcolor=white:fontsize=18:x=20:y=20[wvf2];\
@@ -2524,6 +2526,8 @@ elif [[ -n "${1}" ]] && [[ -z "${RUNTYPE}" ]] ; then
 fi
 
 VRECORD_INPUT_TMP="$(_maketemp .vrecord_input.log)"
+FFREPORT_TMP="$(_maketemp .cffreport.txt)"
+CAP_DISPLAY_TMP="$(_maketemp .caption_scroll.txt)"
 
 # manage an include file to pass variables to gtkdialog
 VRECORD_VARS_FILE="/tmp/v_$(echo "${0}" | sed -e "s/[^A-Za-z0-9.]/_/g")_variables.txt"
@@ -2871,7 +2875,11 @@ fi
 if [[ "${VRECORD_STEPS}" = "2" ]] ; then
     _writeingestlog "Record command" "${RECORD_COMMAND[@]}"
     _writeingestlog "Playback command" "${PLAYER_COMMAND[@]}"
-    "${RECORD_COMMAND[@]}" 2> >(tee "${VRECORD_INPUT_TMP}" 1>&2) | \
+
+    # start background caption process
+    "${SCRIPTDIR}/cchex_to_display" "${FFREPORT_TMP}" "${CAP_DISPLAY_TMP}" > /dev/null 2> /dev/null &
+    CC_PID=$!
+    export FFREPORT="file=${FFREPORT_TMP}:level=32" ; "${RECORD_COMMAND[@]}" 2> >(tee "${VRECORD_INPUT_TMP}" 1>&2) | \
     if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] && [[ "${QCTOOLSXML_CHOICE}" = "Yes, concurrent with recording" ]]; then
         tee >("${PLAYER_COMMAND[@]}") | "${QCLI_COMMAND_PIPE[@]}"
     else


### PR DESCRIPTION
this is a draft to get to https://github.com/amiaopensource/vrecord/issues/810. I starts adds the FFREPORT environmental variable and the play or record command adds the metadata filter to print the hex captions there. A background process called cchex_to_display then periodically skims the end of the FFREPORT and uses a simple ASCII lookup table to convert some of the hex caption data into text and then a drawtext filter uses textfile and reload to draw it live. Currently the live captions only include the basic ASCII and not any extended set, there's also no placement or control codes processed. And it is only implemented in the "Captions" viewer thus far.

Since the captions aren't really fully processed, I'm not using the black boxed style as captions go for, but i'm using a shadowed, right-to-left scroll. I tried to do this all in ffmpeg but I'm not sure it's possible without a video->subtitle filter. @richardpl I'm curious of your thoughts.


https://github.com/user-attachments/assets/0de5f8b2-82df-4c0a-a7c8-9d7da7aecb64

