### PR TITLE
adjust for 24 bit flac

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1816,6 +1816,7 @@ _lookup_choice(){
         "24-bit FLAC")
             MIDDLEOPTIONS_PRES+=(-c:a flac)
             MIDDLEOPTIONS_PRES+=(-sample_fmt s32)
+            MIDDLEOPTIONS_PRES+=(-bits_per_raw_sample:a 24)
             AUDIO_EXT='flac' ;;
         "AAC")
             MIDDLEOPTIONS_PRES+=(-c:a aac) ;;


### PR DESCRIPTION
We noticed yesterday that when selecting 24-bit flac in the September vrecord release, files were ending up 32-bit. I made a small change, but we should discuss:

(1) Is this the right way to do this? I had to use `-bits_per_raw_sample:a` to avoid issues, but I'm not certain this was the right approach. Is dithering something to consider here?
(2) Should we consider simply relabeling the user selection menu and sticking with 32-bit? Pros and cons? We did catch this bc the 32-bit flac MKVs were not playing in VLC, but I'm sure that could be resolved.

Thanks!
