### PR TITLE
Post process subtitle wrap

### DIFF
--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -89,6 +89,7 @@ _update_config_file(){
         echo "DV_RESCUE_OPTION_TC=\"${DV_RESCUE_OPTION_TC}\""
         echo "CC2VTT=\"${CC2VTT}\""
         echo "CC2SRT=\"${CC2SRT}\""
+        echo "CAP2MP4=\"${CAP2MP4}\""
         echo "MEDIA_ID_TYPE=\"${MEDIA_ID_TYPE}\""
         echo "WEBVTT_EXTRA=\"${WEBVTT_EXTRA}\""
         echo "HD_CHOICE=\"${HD_CHOICE}\""

--- a/vrecord
+++ b/vrecord
@@ -829,6 +829,11 @@ OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
                         <default>"${CC2SRT}"</default>
                         <variable>CC2SRT</variable>
                     </checkbox>
+                    <checkbox>
+                        <label>Wrap captions into Access MP4 file</label>
+                        <default>"${CAP2MP4}"</default>
+                        <variable>CAP2MP4</variable>
+                    </checkbox>
                 </vbox>
             </frame>
             <frame FADGI WebVTT header>
@@ -3186,6 +3191,21 @@ if [[ "${DEVICE_INPUT_CHOICE}" = 0 ]] ; then
         fi
         if [[ "${CC2SRT}" = 'true' ]] ; then
             "${FFMPEG_BIN}" -nostdin -v 0 -y -i "${CAPTION_SCC}" -f srt -c:s srt - | sed -E 's/\\h//g; s/\{\\an[0-9]\}//g; s/<[^>]+>//g' "${CAPTION_SCC%.*}.srt"
+        fi
+        if [[ "${CAP2MP4}" = 'true' && "${MP4_CHOICE}" = 'true' ]] ; then
+            if [[ -s "${CAPTION_SCC%.*}.vtt" ]] ; then
+                CAP2EMBED="${CAPTION_SCC%.*}.vtt"
+            elif [[ -s "${CAPTION_SCC%.*}.srt" ]] ; then
+                CAP2EMBED="${CAPTION_SCC%.*}.srt"
+            else
+                CAP2EMBED="$(_maketemp .vtt)"
+                "${FFMPEG_BIN}" -nostdin -v 0 -y -i "${CAPTION_SCC}" -f webvtt - | sed -E 's/\\h//g; s/\{\\an[0-9]\}//g; s/<[^>]+>//g' > "${CAP2EMBED}"
+            fi
+            _report -dt "Wrapping the extracted captions into the Access MP4 file..."
+            "${FFMPEG_BIN}" -nostdin -v 0 -y -i "${MP4NAME}" -i "${CAP2EMBED}" -map 0:v -map 0:a -map 1:s -c:v copy -c:a copy -c:s mov_text "${MP4NAME}.subs.mp4"
+            if [[ $? -eq 0 ]]; then
+                mv -v "${MP4NAME}.subs.mp4" "${MP4NAME}"
+            fi
         fi
     fi
 


### PR DESCRIPTION
This addresses the last item in https://github.com/amiaopensource/vrecord/issues/869#issuecomment-3725400741 and embeds the captions into the access mp4 as a subtitle track.
Doing so with the preservation file will be a bit more complex since the approach could vary per format and the post checks should be more careful.