### PR TITLE
remove option for slice count

### DIFF
--- a/Resources/Documentation/settings.md
+++ b/Resources/Documentation/settings.md
@@ -30,8 +30,6 @@ NOTE: Setting the video input in Desktop Video Setup to match this option will r
 
 **Select bit depth for video** — Choose the level of bit depth you would like for your video file. Vrecord supports 10 and 8-bit video capture.
 
-**Select FFV1 slice count** - If you select FFV1 as your video codec, you will be prompted to choose between a number of "slice count" options. An error detection/correction mechanism specific to FFV1, slices allow for each frame of video to be split into sub-sections, which will, in turn, each receive their own CRC checksum value. Keep in mind that the higher the slice count, the larger the resulting file.
-
 **Select codec for audio** - Choose how you would like the audio signal to be encoded digitally. You can choose between uncompressed or lossless codecs.
 
 **Select audio channel mapping** — Choose how you want the audio to be captured. Currently vrecord captures audio at 24-bits and can only capture 4 tracks. The options are: 

--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -47,7 +47,6 @@ _update_config_file(){
         echo "AUDIO_INPUT_CHOICE=\"${AUDIO_INPUT_CHOICE}\""
         echo "CONTAINER_CHOICE=\"${CONTAINER_CHOICE}\""
         echo "VIDEO_CODEC_CHOICE=\"${VIDEO_CODEC_CHOICE}\""
-        echo "FFV1_SLICE_CHOICE=\"${FFV1_SLICE_CHOICE}\""
         echo "AUDIO_CODEC_CHOICE=\"${AUDIO_CODEC_CHOICE}\""
         echo "AUDIO_DEV_CHOICE=\"${AUDIO_DEV_CHOICE}\""
         echo "AUDIO_MODE_CODEC_CHOICE=\"${AUDIO_MODE_CODEC_CHOICE}\""

--- a/vrecord
+++ b/vrecord
@@ -392,11 +392,7 @@ _gtk_vbox_list() {
     fi
 
     _get_list_extras(){
-        if [[ "${VARIABLE_NAME}" == "VIDEO_CODEC_CHOICE" ]] ; then
-            echo '<action condition="command_is_true( [ \"$VIDEO_CODEC_CHOICE\" = \"FFV1 version 3\" ] && echo true)">enable:FFV1_SLICE_CHOICE</action>
-                  <action condition="command_is_true( [ \"$VIDEO_CODEC_CHOICE\" != \"FFV1 version 3\" ] && echo true)">disable:FFV1_SLICE_CHOICE</action>
-                  <action type="refresh">VRECORD_OUTPUT_NAME</action>'
-        elif [[ "${VARIABLE_NAME}" == "CONTAINER_CHOICE" ]] ; then
+        if [[ "${VARIABLE_NAME}" == "CONTAINER_CHOICE" ]] ; then
             echo '<action condition="command_is_true( [ \"$CONTAINER_CHOICE\" = \"Matroska\" ] && echo true)">enable:EMBED_LOGS_CHOICE</action>
                   <action condition="command_is_true( [ \"$CONTAINER_CHOICE\" != \"Matroska\" ] && echo true)">disable:EMBED_LOGS_CHOICE</action>
                   <action type="refresh">VRECORD_OUTPUT_NAME</action>'
@@ -1032,7 +1028,6 @@ DECKLINK_INPUT_GUI=$(cat << DECKLINK_FORM
             <hbox space-expand="true">
                 $(_gtk_vbox_list "EMBED_LOGS_CHOICE"        "100" "Embed digitization logs in video file (Matroska ONLY)" "${EMBED_LOGS_OPTIONS[@]}")
                 $(_gtk_vbox_list "CONTAINER_CHOICE"         "100" "Select File Format"            "${CONTAINER_OPTIONS[@]}")
-                $(_gtk_vbox_list "FFV1_SLICE_CHOICE"        "100" "FFV1 Slice Count"              "${FFV1_SLICE_OPTIONS[@]}")
                 $(_gtk_vbox_list "VIDEO_CODEC_CHOICE"       "160" "Select Video Codec"            "${VIDEO_CODEC_OPTIONS[@]}")
                 $(_gtk_vbox_list "AUDIO_CODEC_CHOICE"       "100" "Select Audio Codec"            "${AUDIO_CODEC_OPTIONS[@]}")
             </hbox>
@@ -1829,7 +1824,7 @@ _lookup_choice(){
         "FFV1 version 3")
             _add_mediaconch_rule_set "${CODEC_FFV1_TEST}"
             VIDEOCODECNAME="FFV1 version 3"
-            MIDDLEOPTIONS_PRES+=(-c:v ffv1 -level 3 -g 1 -slices "${FFV1_SLICE_CHOICE}" -slicecrc 1)
+            MIDDLEOPTIONS_PRES+=(-c:v ffv1 -level 3 -g 1 -slicecrc 1)
             SUFFIX="_ffv1" ;;
         "JPEG2000")
             VIDEOCODECNAME="JPEG2000"
@@ -2838,7 +2833,6 @@ AUDIO_INPUT_OPTIONS=("Analog" "SDI Embedded Audio" "Digital Audio (AES/EBU)")
 CONTAINER_OPTIONS=("QuickTime" "Matroska" "AVI" "MXF" "MP4")
 DV_CONTAINER_OPTIONS=("DV" "Matroska" "QuickTime")
 VIDEO_CODEC_OPTIONS=("Uncompressed Video" "FFV1 version 3" "JPEG2000" "ProRes" "ProRes (HQ)" "h264" "HuffYUV")
-FFV1_SLICE_OPTIONS=("4" "6" "9" "12" "16" "24" "30")
 AUDIO_CODEC_OPTIONS=("24-bit PCM" "24-bit FLAC" "AAC")
 AUDIO_CHANNEL_CHOICE_OPTIONS=("Mono" "Stereo")
 AUDIO_MODE_SR_CHOICE_OPTIONS=("96 kHz" "48 kHz" "44.1 kHz")
@@ -2967,9 +2961,6 @@ fi
 if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
     _review_option "CONTAINER_CHOICE" "${CONTAINER_OPTIONS[@]}"
     _review_option "VIDEO_CODEC_CHOICE" "${VIDEO_CODEC_OPTIONS[@]}"
-    if [[ "${VIDEO_CODEC_CHOICE}" = "FFV1 version 3" ]] ; then
-        _review_option -n -d "16" "FFV1_SLICE_CHOICE" "${FFV1_SLICE_OPTIONS[@]}"
-    fi
     _review_option "AUDIO_CODEC_CHOICE" "${AUDIO_CODEC_OPTIONS[@]}"
 elif [[ "${DEVICE_INPUT_CHOICE}" = "1" ]] ; then
     _review_option "DV_CONTAINER_CHOICE" "${DV_CONTAINER_OPTIONS[@]}"


### PR DESCRIPTION
i'm curious what people think but this PR remove the option to set the ffv1 slice count. Instead it would just default to what ffmpeg picks, which is 4 for SD (720x486) and 20 for HD (1920x1080). Otherwise since we now manage HD and SD, having one global slice count option doesn't make sense.

Alternatively is we don't like the default ffmpeg slice counts, then we could set our own pick for each video standard, like 12 for SD and 30 for HD? Either way I think either setting a vrecord community selected slice count per standard or going with the ffmpeg defaults would be preferable to a user-selected slice count.

Thoughts?