### PR TITLE
correct a dvpackager label

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -1172,7 +1172,7 @@ DVRESCUE_INPUT_GUI=$(cat << DVRESCUE_FORM
                             </text>
                             <checkbox>
                                 $(if [[ ${DVPACKAGER_INSTALLED} != "true" ]] ; then echo "<sensitive>false</sensitive>" ; fi)
-                                <label>Create technical subtitle track</label>
+                                <label>Embed captions as subtitles</label>
                                 <default>"${DV_RESCUE_OPTION_TC}"</default>
                                 <variable>DV_RESCUE_OPTION_TC</variable>
                             </checkbox>


### PR DESCRIPTION
DV_RESCUE_OPTION_TC enables `-S` in dvpackager which is about embedded the extracted caption data as a subtitle. The label here was incorrect. I opted to leave the variable the same so that users that have been using `-S` don't need to reconfigure this.