### PR TITLE
Added gop size 12 to access mp4

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -3026,7 +3026,7 @@ if [[ "${DEVICE_INPUT_CHOICE}" = "0" ]] ; then
         RECORDINGFILTER_MP4+=",bwdif,format=yuv420p"
         RECORD_COMMAND_MP4+=(-filter_complex "[0:v:0]${RECORDINGFILTER_MP4#,*}[mp4_v_out];${AUDIOMAP_MP4}")
         MP4NAME="${DIR}/${FULL_OUTPUT_ID}.mp4"
-        EXTRAOUTPUTS+=("${MIDDLEOPTIONS_ALL[@]}" -movflags write_colr+faststart "${RECORD_COMMAND_MP4[@]}" -c:v h264 -profile:v main -level "${ACCESS_MP4_LEVEL}" -c:a aac -map "[mp4_v_out]" "${AUDIO_CHANNEL_MAP[@]:2}" "${MP4NAME}")
+        EXTRAOUTPUTS+=("${MIDDLEOPTIONS_ALL[@]}" -movflags write_colr+faststart "${RECORD_COMMAND_MP4[@]}" -c:v h264 -g 12 -profile:v main -level "${ACCESS_MP4_LEVEL}" -c:a aac -map "[mp4_v_out]" "${AUDIO_CHANNEL_MAP[@]:2}" "${MP4NAME}")
     fi
     if [[ "${FORMAT}" = "matroska" ]] ; then
         _review_option "EMBED_LOGS_CHOICE" "${EMBED_LOGS_OPTIONS[@]}"


### PR DESCRIPTION
added gop size 12 (-g 12) to the access mp4 creation to avoid MP4s with gigantic GOP sizes. I tested this to make sure the FFV1 files were still -g 1 and it appears they are. It'd be nice if someone else could check that out too. 