### PR TITLE
Update linux docs

### DIFF
--- a/Resources/Documentation/linux_installation.md
+++ b/Resources/Documentation/linux_installation.md
@@ -21,6 +21,7 @@ The following instructions aim to minimize use of Homebrew installs for packages
   - `sudo apt-get install mkvtoolnix`
   - `sudo apt-get install mediaconch`
   - `sudo apt-get install mpv`
+  - `sudo apt-get install bison`
 * Install the following dependencies for enabling DV capture in vrecord's FFmpeg build:
   - `sudo apt-get install libiec61883-dev`
   - `sudo apt-get install libraw1394-dev`

--- a/Resources/Documentation/linux_installation.md
+++ b/Resources/Documentation/linux_installation.md
@@ -53,10 +53,6 @@ The following instructions aim to minimize use of Homebrew installs for packages
 * `brew install decklinksdk && brew install ffmpeg-ma --with-iec61883 && brew install gtkdialog` _Note:_ Some users on Ubuntu have reported installation problems with `gtkdialog` at step. See [this note](https://github.com/amiaopensource/homebrew-amiaos/blob/master/TROUBLESHOOTING.md#vrecord)  at the AMIA Open Source Homebrew repository for a possible fix.
 * `brew install vrecord`
 
-### Fix conflicting SDL2 dependencies
-* `brew uninstall --ignore-dependencies sdl2`
-* `sudo apt install libsdl2-dev`
-* This step may not be required if Brew has been configured lower in $PATH than standard system directories.
 
 # Instructions/Tips for other Linux Distributions
 ## Linux Mint

--- a/Resources/Documentation/linux_installation.md
+++ b/Resources/Documentation/linux_installation.md
@@ -12,13 +12,6 @@ The following instructions aim to minimize use of Homebrew installs for packages
 * Download and install the latest version of the [QCTools CLI tool](https://mediaarea.net/QCTools/Download/Ubuntu) from the MediaArea website
 * Optional: If DV wrapping and splitting is desired, download and install [DVRescue](https://mediaarea.net/DVRescue) from the MediaArea website.
 
-### Programs to be installed via PPA
-
-* Install MPV with the following steps:
-  - Add the MPV PPA with: `sudo add-apt-repository ppa:mc3man/mpv-tests`
-  - Update package manager with: `sudo apt-get update`
-  - Install MPV with `sudo apt-get install mpv`
-
 ### Programs to be installed via standard package manager
 
 * Use the following commands to install additional dependencies for full vrecord use:
@@ -27,6 +20,7 @@ The following instructions aim to minimize use of Homebrew installs for packages
   - `sudo apt-get install xmlstarlet`
   - `sudo apt-get install mkvtoolnix`
   - `sudo apt-get install mediaconch`
+  - `sudo apt-get install mpv`
 * Install the following dependencies for enabling DV capture in vrecord's FFmpeg build:
   - `sudo apt-get install libiec61883-dev`
   - `sudo apt-get install libraw1394-dev`


### PR DESCRIPTION
Did a quick cleanup of the Linux install docs to remove some outdated advice and to include some other things that have come up.

* Adds `bison` to install list
* Removes note about uninstalling sdl2 as I don't think this is an issue anymore
* Removes instructions about mpv PPA install as I think normal package managers should work fine for this now