### PR TITLE
add linux dependency install script

### DIFF
--- a/Release/linux-dependencies.sh
+++ b/Release/linux-dependencies.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+sudo apt-get install -y --no-install-recommends \
+build-essential \
+libgtk2.0-dev \
+libgtk-3-dev \
+bison \
+flex \
+texinfo \
+git \
+mkvtoolnix \
+gnuplot \
+xmlstarlet \
+mpv \
+libiec61883-dev \
+libraw1394-dev \
+libavc1394-dev \
+libavc1394-tools


### PR DESCRIPTION
Adds basic script for supporting non-Brew dependencies on Linux (Ubuntu). Once merged will integrate into install docs as option to be run via `curl` to simplify install process for Linux users.