### PR TITLE
don't use timecode_format on faux inputs

### DIFF
--- a/vrecord
+++ b/vrecord
@@ -665,7 +665,9 @@ _setup_vrecord_process(){
             FFPLAY_OPTIONS+=(-f lavfi "amovie='pipe\:0',${PLAYBACKFILTER}")
         else
             if [[ "${VRECORD_STEPS}" = "1" ]] ; then
-                FFPLAY_OPTIONS+=(-timecode_format all)
+                if [[ "${SIGNAL_INPUT}" != 'true' ]] && [[ -z "${ALT_INPUT}" ]] ; then
+                    FFPLAY_OPTIONS+=(-timecode_format all)
+                fi
                 FFPLAY_OPTIONS+=("${GRAB_INPUT[@]}")
             else
                 FFPLAY_OPTIONS+=(-i -)


### PR DESCRIPTION
This fixes an issue when running passthrough on a file input.