### PR TITLE
Color free terminal alerts

### DIFF
--- a/Resources/vrecord_functions
+++ b/Resources/vrecord_functions
@@ -92,6 +92,7 @@ _update_config_file(){
         echo "MEDIA_ID_TYPE=\"${MEDIA_ID_TYPE}\""
         echo "WEBVTT_EXTRA=\"${WEBVTT_EXTRA}\""
         echo "HD_CHOICE=\"${HD_CHOICE}\""
+        echo "COLOR_SAFE=\"${COLOR_SAFE}\""
     } > "${CONFIG_FILE}"
     . "${CONFIG_FILE}"
 }

--- a/vrecord
+++ b/vrecord
@@ -74,11 +74,19 @@ _get_iso8601(){
 }
 
 _report(){
-    local RED="$(tput setaf 1)"    # Red      - For Warnings
-    local BG_RED="$(tput setab 1)"    # Background Red      - For STRONG Warnings
-    local GREEN="$(tput setaf 2)"  # Green    - For Declarations
-    local BLUE="$(tput setaf 4)"   # Blue     - For Questions
-    local NC="$(tput sgr0)"        # No Color
+    if [[ "${COLOR_SAFE}" == 'true' ]] ; then
+        local RED="$(tput bold)$(tput smso)"   # Red      - For Warnings
+        local BG_RED="$(tput setab 1)"    # Background Red      - For STRONG Warnings
+        local GREEN="$(tput smso)"  # Green    - For Declarations
+        local BLUE=""$(tput sitm)$(tput smso)""   # Blue     - For Questions
+        local NC="$(tput rmso)$(tput ritm)"        # No Color
+    else
+        local RED="$(tput setaf 1)"    # Red      - For Warnings
+        local BG_RED="$(tput setab 1)"    # Background Red      - For STRONG Warnings
+        local GREEN="$(tput setaf 2)"  # Green    - For Declarations
+        local BLUE="$(tput setaf 4)"   # Blue     - For Questions
+        local NC="$(tput sgr0)"        # No Color
+    fi
     local COLOR=""
     local STARTMESSAGE=""
     local ECHOOPT=""
@@ -808,7 +816,7 @@ PLAYBACK_OPT_GUI="
 OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
 <frame Preferences>
     <hbox>
-        <notebook tab-labels="Player|Aspect Ratio|Closed Captioning|FADGI WebVTT header">
+        <notebook tab-labels="Player|Aspect Ratio|Closed Captioning|FADGI WebVTT header|Color Options">
             <frame Player Settings>
                 <hbox>
                 $(_gtk_vbox_list "WAVEFORM_SCALE_CHOICE" "100" "Select Waveform Scale"            "${WAVEFORM_SCALE_OPTIONS[@]}")
@@ -875,6 +883,18 @@ OPTIONAL_TOOLS_GUI=$(cat << CONFIG_FORM
                             <variable>WEBVTT_EXTRA</variable>
                         </entry>
                     </vbox>
+                </vbox>
+            </frame>
+            <frame Color Options>
+                <vbox>
+                    <text width-chars="-1">
+                        <label>Change color settings used in vrecord</label>
+                    </text>
+                    <checkbox>
+                        <label>Enable color free alerts</label>
+                        <default>"${COLOR_SAFE}"</default>
+                        <variable>COLOR_SAFE</variable>
+                    </checkbox>
                 </vbox>
             </frame>
         </notebook>

--- a/vrecord
+++ b/vrecord
@@ -75,14 +75,14 @@ _get_iso8601(){
 
 _report(){
     if [[ "${COLOR_SAFE}" == 'true' ]] ; then
-        local RED="$(tput bold)$(tput smso)"   # Red      - For Warnings
-        local BG_RED="$(tput setab 1)"    # Background Red      - For STRONG Warnings
-        local GREEN="$(tput smso)"  # Green    - For Declarations
-        local BLUE=""$(tput sitm)$(tput smso)""   # Blue     - For Questions
-        local NC="$(tput rmso)$(tput ritm)"        # No Color
+        local RED="$(tput bold)$(tput smso)"    # Bold text and inverted background - For Warnings
+        local BG_RED="$(tput setab 1)"          # Background Red - For STRONG Warnings
+        local GREEN="$(tput smso)"              # Inverted background - For Declarations
+        local BLUE=""$(tput sitm)$(tput smso)"" # Italic text and inverted background - For Questions
+        local NC="$(tput rmso)$(tput ritm)"     # No Color
     else
         local RED="$(tput setaf 1)"    # Red      - For Warnings
-        local BG_RED="$(tput setab 1)"    # Background Red      - For STRONG Warnings
+        local BG_RED="$(tput setab 1)" # Background Red      - For STRONG Warnings
         local GREEN="$(tput setaf 2)"  # Green    - For Declarations
         local BLUE="$(tput setaf 4)"   # Blue     - For Questions
         local NC="$(tput sgr0)"        # No Color


### PR DESCRIPTION
This adds an option in settings tab to disable usage of color in vrecords terminal alerts. Warnings are mapped as follows:
* red -> inverted background/bold
* blue -> inverted background/italics
* green -> inverted background